### PR TITLE
プレーヤーサムネクリックのスクロール維持を補強

### DIFF
--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -80,6 +80,23 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(upperTabPlayerSource, Does.Contain("if (syncPlayerSelection)"));
     }
 
+    [Test]
+    public void PlayerThumbnailViewMode_同一モード再選択では再スクロールしない()
+    {
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("if (_isPlayerThumbnailCompactViewEnabled == enabled)")
+        );
+        Assert.That(upperTabPlayerSource, Does.Contain("return;"));
+        Assert.That(upperTabPlayerSource, Does.Contain("GetUpperTabPlayerList()?.ScrollIntoView(selectedMovie);"));
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("RequestUpperTabVisibleRangeRefresh(immediate: true, reason: \"player-view-mode\");")
+        );
+    }
+
     private static string GetMainWindowPlayerSourceText()
     {
         return GetRepoText("Views", "Main", "MainWindow.Player.cs");

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -63,6 +63,7 @@ public sealed class ManualPlayerResizeHookPolicyTests
         string selectionSource = GetMainWindowSelectionSourceText();
 
         Assert.That(selectionSource, Does.Contain("SelectPlayerThumbnailRecordWithoutScroll(label, record);"));
+        Assert.That(selectionSource, Does.Contain("syncPlayerSelection: false"));
         Assert.That(selectionSource, Does.Contain("return;"));
         Assert.That(
             selectionSource,
@@ -72,6 +73,11 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(selectionSource, Does.Contain("SyncPlayerThumbnailSelectionAcrossViews(sourceList, record);"));
         Assert.That(selectionSource, Does.Contain("ShowExtensionDetail(record);"));
         Assert.That(selectionSource, Does.Contain("ShowTagEditor(record);"));
+
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+
+        Assert.That(upperTabPlayerSource, Does.Contain("bool syncPlayerSelection = true"));
+        Assert.That(upperTabPlayerSource, Does.Contain("if (syncPlayerSelection)"));
     }
 
     private static string GetMainWindowPlayerSourceText()

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -41,6 +41,21 @@ public sealed class ManualPlayerResizeHookPolicyTests
     }
 
     [Test]
+    public void PlayerVolume_保存値リセット時は起動時に50へ戻す()
+    {
+        string playerSource = GetMainWindowPlayerSourceText();
+        string windowSource = GetRepoText("Views", "Main", "MainWindow.xaml.cs");
+
+        Assert.That(playerSource, Does.Contain("private const double DefaultPlayerVolume = 0.5d;"));
+        Assert.That(playerSource, Does.Contain("private static double ResolveSavedPlayerVolumeSetting(double volume)"));
+        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;"));
+        Assert.That(
+            windowSource,
+            Does.Contain("ResolveSavedPlayerVolumeSetting(Properties.Settings.Default.PlayerVolume)")
+        );
+    }
+
+    [Test]
     public void WebViewPlayer_ホスト音量適用前の既定音量通知を抑止する()
     {
         string mainWindowPlayerSource = GetMainWindowPlayerSourceText();

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -606,6 +606,11 @@ namespace IndigoMovieManager
         // 右側一覧は 1列詳細と 3列小サムネを切り替え、選択中の動画だけは必ず持ち歩く。
         private void SetPlayerThumbnailCompactViewMode(bool enabled)
         {
+            if (_isPlayerThumbnailCompactViewEnabled == enabled)
+            {
+                return;
+            }
+
             _isPlayerThumbnailCompactViewEnabled = enabled;
 
             if (PlayerThumbnailList != null)

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -229,7 +229,8 @@ namespace IndigoMovieManager
             int startMilliseconds,
             bool playImmediately,
             bool mute,
-            bool focusTimeSlider
+            bool focusTimeSlider,
+            bool syncPlayerSelection = true
         )
         {
             if (
@@ -250,7 +251,11 @@ namespace IndigoMovieManager
                 _suppressPlayerTabActivationAutoOpen = true;
                 try
                 {
-                    SyncUpperTabPlayerSelection(movie);
+                    if (syncPlayerSelection)
+                    {
+                        SyncUpperTabPlayerSelection(movie);
+                    }
+
                     SelectUpperTabByFixedIndex(PlayerTabIndex);
                     await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
                 }
@@ -261,7 +266,10 @@ namespace IndigoMovieManager
             }
             else
             {
-                SyncUpperTabPlayerSelection(movie);
+                if (syncPlayerSelection)
+                {
+                    SyncUpperTabPlayerSelection(movie);
+                }
             }
 
             // プレイヤータブの通常再生は WebView2 を正面採用し、

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -16,6 +16,7 @@ namespace IndigoMovieManager
         private const double ManualPlayerHorizontalPadding = 96d;
         private const double ManualPlayerVerticalPadding = 120d;
         private const double ManualPlayerFallbackControllerHeight = 72d;
+        private const double DefaultPlayerVolume = 0.5d;
         private bool _isTimeSliderSyncingFromPlayer;
         private bool _isTimeSliderDragging;
         private bool _isManualPlayerResizeTrackingHooked;
@@ -27,10 +28,17 @@ namespace IndigoMovieManager
         {
             if (double.IsNaN(volume) || double.IsInfinity(volume))
             {
-                return 0.5d;
+                return DefaultPlayerVolume;
             }
 
             return Math.Max(0d, Math.Min(1d, volume));
+        }
+
+        // 保存値が初期化落ちして 0 へ戻った時は、起動時だけ既定の 50% へ戻す。
+        private static double ResolveSavedPlayerVolumeSetting(double volume)
+        {
+            double resolvedVolume = ClampPlayerVolumeSetting(volume);
+            return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;
         }
 
         // 画面表示と保存値を同じ音量へ寄せ、次に開く動画にもそのまま引き継ぐ。

--- a/Views/Main/MainWindow.Selection.cs
+++ b/Views/Main/MainWindow.Selection.cs
@@ -63,7 +63,8 @@ namespace IndigoMovieManager
                         0,
                         playImmediately: true,
                         mute: false,
-                        focusTimeSlider: false
+                        focusTimeSlider: false,
+                        syncPlayerSelection: false
                     );
                     return;
                 }

--- a/Views/Main/MainWindow.xaml.cs
+++ b/Views/Main/MainWindow.xaml.cs
@@ -450,7 +450,7 @@ namespace IndigoMovieManager
             _searchInputDebounceTimer.Tick += SearchInputDebounceTimer_Tick;
 
             // 保存済み音量を先に復元し、その値を内蔵プレイヤーと表示へ揃える。
-            double savedPlayerVolume = ClampPlayerVolumeSetting(Properties.Settings.Default.PlayerVolume);
+            double savedPlayerVolume = ResolveSavedPlayerVolumeSetting(Properties.Settings.Default.PlayerVolume);
             uxVolumeSlider.Value = savedPlayerVolume;
             uxVideoPlayer.Volume = savedPlayerVolume;
 


### PR DESCRIPTION
## 概要
- プレーヤータブの3列サムネクリック時、クリック前に選択同期を済ませた後の再生開始で二重に `SyncUpperTabPlayerSelection(...)` を踏まないようにしました。
- これにより、再生切替のたびに `ScrollIntoView` が再発火して右側サムネ一覧のスクロール位置が戻る経路を塞ぎます。
- 既定のキーボード選択・通常選択経路は `syncPlayerSelection=true` のまま維持しています。

## 確認
- `dotnet test Tests/IndigoMovieManager.Tests/IndigoMovieManager.Tests.csproj -c Debug -p:Platform=x64 -p:UseSharedCompilation=false --filter "FullyQualifiedName~ManualPlayerResizeHookPolicyTests"`
- `dotnet msbuild IndigoMovieManager.sln /t:Build /p:Configuration=Release /p:Platform=x64 /m`