### PR TITLE
本線UI操作とpollの重複処理を軽量化

### DIFF
--- a/AI向け_現在の全体プラン_workthree_2026-03-20.md
+++ b/AI向け_現在の全体プラン_workthree_2026-03-20.md
@@ -4,7 +4,10 @@
 
 変更概要:
 - watch query-only 局所更新が full reload へ戻る時の理由を `changed_path_fallback` としてログへ出し、`no-changed-movies` / `filter-unavailable` / `dup-hash-dirty` を実機ログだけで切り分けられるようにした
+- watch キュー圧縮で trigger / path の因果が消えたように見える経路へログを足し、圧縮前後の理由を `debug-runtime.log` で追えるようにした
 - WebView Player の停止・切替時に pending の `user-priority` 解放を `ResetWebViewPlayerSurface()` で畳み、`NavigationCompleted` 後着時に watch / poll defer が残り続ける経路を塞いだ
+- サムネ進捗の初期 snapshot 全走査を UI 初期表示から外して背景化し、下部 `ThumbnailProgress` 初期化が first-page と入力を押しのけないようにした
+- 検索確定後の履歴保存・履歴再読込を背景化し、検索完了直後の UI 導線に残っていた DB write/read を外した
 - 全体計画を再構築し、優先軸を `UIスレッドを空ける`、`全面再評価を減らす`、`入力優先を守る` の 3 本へ整理した
 - `Watcher.cs` 薄化は目的ではなく、UI thread / queue / shutdown の詰まりを減らすための手段として位置づけ直した
 - 本線の次手を `watcher shutdown / queue 境界の安定化`、`diff-first UI の残り潰し`、`起動 warm path`、`visible-first / Player表示` の順へ組み替えた
@@ -37,6 +40,7 @@
 - 再読込ボタンは `FilterAndSort(true)` と `Manual scan` を直列化し、その間だけ `Watch / EverythingPoll` を抑止して、全件DB再構築と手動全域走査が同時に走らないようにした
 - さらに `manual-reload` 抑止解除直後の catch-up `Watch` は積まず、直前の `Manual scan` で十分な場面に `watch_zero_diff reconcile` の全量再走査を重ねないようにした
 - 下部 `ThumbnailProgress` タブが非表示の時は snapshot refresh を dirty 記録だけへ寄せ、`CreateThumbAsync` 完了ごとの hidden UI 更新を抑えて `activity=None` の後段負荷を減らし始めた
+- 下部 `ThumbnailProgress` の初期 snapshot 全走査は背景側で作り、UI には反映だけを返す形へ寄せた
 - UI を含む高速化の抜本改善プランを追加し、P4 を「全面再評価中心から差分反映中心へ変える」軸で補足
 - watch query-only reload に `changed paths` を通し、検索結果集合ベースの局所再評価を追加
 - watch change set に `ChangeKind` を追加し、empty search の局所復帰で per-path filter をさらに削減
@@ -268,6 +272,8 @@
 - さらに ASCII 検索では `Movie_Name / Movie_Path / Tags / Comment1-3 / Roma` だけを見る軽量投影 cache を使い、`kana / katakana` 派生列の全件生成を避けて `filter-movies` の詰まりを減らし始めた
 - 実機ログでは `ggggg` のような ASCII 検索で `filter-movies` 詰まりが出ていたが、軽量投影 cache 追加後は検索完了まで進むことを確認した。ASCII 検索の主因は比較方式そのものより `kana / katakana` 派生列の全件生成だったと判断する
 - さらに textbox 入力の重さは `SearchBox_TextChanged(...)` ごとの `RestartThumbnailTask()` 連打が主因だったため、通常入力中はサムネ常駐を再起動せず、実検索の瞬間だけ再起動する形へ寄せた
+- さらに検索確定後の履歴保存・履歴再読込は背景 task に逃がし、DB が同じ時だけ UI へ履歴候補を反映する形へ寄せた
+- watch query-only full 戻り理由ログ、watch キュー圧縮の因果ログ、WebView 停止時の `user-priority` pending 解放、サムネ進捗初期全走査の背景化は完了済みとして扱う
 - `UiHangNotificationCoordinator` と `NativeOverlayHost` の停止経路を確認し、オーバーレイ残留は「owner なし native popup を別スレッド dispatcher 依存で止めていること」が主因候補と整理した。直し方は `owner 付与 -> caller 側即 hide -> join timeout 後の強制閉鎖 -> shutdown 専用 safety fuse` の順に固定する
 
 ### 7.2 再構築後の次の着手順
@@ -276,7 +282,7 @@
 2. UI スレッドを塞ぐ入口を、`search / reload / Player / watcher / thumbnail / skin` の順に棚卸しし、snapshot / queue / defer / background 化のどれで解くか決める
 3. watcher / poll / shutdown は、`FileSystemWatcher` 入力停止、queue complete、created pipeline drain、Everything poll 停止の順序を固定し、bounded drain と timeout log を持たせる
 4. watch 起点の UI 再読込は、差分反映優先でさらに縮小できる箇所を切り分ける
-  現在は `changed paths + ChangeKind + DirtyFields + ObservedState` ベースの局所 filter / 直接復帰 / rename reuse-order / existing movie file属性反映 / query-only incremental watch時の必要時限定probe / `{dup}` 時の安全fallback / full reload 戻り理由ログまで。次は queue 圧縮で消える trigger / path 因果をログで追えるようにする
+  現在は `changed paths + ChangeKind + DirtyFields + ObservedState` ベースの局所 filter / 直接復帰 / rename reuse-order / existing movie file属性反映 / query-only incremental watch時の必要時限定probe / `{dup}` 時の安全fallback / full reload 戻り理由ログ / queue 圧縮因果ログまで。次は残った full 戻り条件を減らせるかを実機ログで選ぶ
 5. visible-first / Player / 画像供給は、起動 first-page とユーザー操作を優先し、off-screen decode / metadata / 補助 UI bind を後ろへ送る
 6. 検索高速化は本線内では既存 `SearchService.FilterMovies(...)` 正本を維持し、投影 cache や比較コスト削減のような仕様を変えない範囲に留める。`SearchSidecar` は別リポ検証を継続する
 7. `skin` は別レーンとして、runtime bridge の terminal / `changeSkin` 境界固定と `refresh / catalog / DB` 分離を混ぜずに進める

--- a/AI向け_現在の全体プラン_workthree_2026-03-20.md
+++ b/AI向け_現在の全体プラン_workthree_2026-03-20.md
@@ -1,8 +1,10 @@
 # AI向け 現在の全体プラン（開発本線） 2026-03-20
 
-最終更新日: 2026-04-24
+最終更新日: 2026-04-27
 
 変更概要:
+- watch query-only 局所更新が full reload へ戻る時の理由を `changed_path_fallback` としてログへ出し、`no-changed-movies` / `filter-unavailable` / `dup-hash-dirty` を実機ログだけで切り分けられるようにした
+- WebView Player の停止・切替時に pending の `user-priority` 解放を `ResetWebViewPlayerSurface()` で畳み、`NavigationCompleted` 後着時に watch / poll defer が残り続ける経路を塞いだ
 - 全体計画を再構築し、優先軸を `UIスレッドを空ける`、`全面再評価を減らす`、`入力優先を守る` の 3 本へ整理した
 - `Watcher.cs` 薄化は目的ではなく、UI thread / queue / shutdown の詰まりを減らすための手段として位置づけ直した
 - 本線の次手を `watcher shutdown / queue 境界の安定化`、`diff-first UI の残り潰し`、`起動 warm path`、`visible-first / Player表示` の順へ組み替えた
@@ -274,7 +276,7 @@
 2. UI スレッドを塞ぐ入口を、`search / reload / Player / watcher / thumbnail / skin` の順に棚卸しし、snapshot / queue / defer / background 化のどれで解くか決める
 3. watcher / poll / shutdown は、`FileSystemWatcher` 入力停止、queue complete、created pipeline drain、Everything poll 停止の順序を固定し、bounded drain と timeout log を持たせる
 4. watch 起点の UI 再読込は、差分反映優先でさらに縮小できる箇所を切り分ける
-  現在は `changed paths + ChangeKind + DirtyFields + ObservedState` ベースの局所 filter / 直接復帰 / rename reuse-order / existing movie file属性反映 / query-only incremental watch時の必要時限定probe / `{dup}` 時の安全fallback まで。次は full reload へ戻る理由を明示し、`Hash` や重複検索のような危険条件だけを安全側へ戻す
+  現在は `changed paths + ChangeKind + DirtyFields + ObservedState` ベースの局所 filter / 直接復帰 / rename reuse-order / existing movie file属性反映 / query-only incremental watch時の必要時限定probe / `{dup}` 時の安全fallback / full reload 戻り理由ログまで。次は queue 圧縮で消える trigger / path 因果をログで追えるようにする
 5. visible-first / Player / 画像供給は、起動 first-page とユーザー操作を優先し、off-screen decode / metadata / 補助 UI bind を後ろへ送る
 6. 検索高速化は本線内では既存 `SearchService.FilterMovies(...)` 正本を維持し、投影 cache や比較コスト削減のような仕様を変えない範囲に留める。`SearchSidecar` は別リポ検証を継続する
 7. `skin` は別レーンとして、runtime bridge の terminal / `changeSkin` 境界固定と `refresh / catalog / DB` 分離を混ぜずに進める

--- a/BottomTabs/ThumbnailProgress/MainWindow.BottomTab.ThumbnailProgress.cs
+++ b/BottomTabs/ThumbnailProgress/MainWindow.BottomTab.ThumbnailProgress.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -20,6 +21,7 @@ namespace IndigoMovieManager
         // 一時対応: サムネイル作成中ダイアログ表示を止める。
         private static readonly bool TemporaryPauseThumbnailProgressDialog = true;
         private const int ThumbnailProgressUiIntervalMs = 500;
+        private const int ThumbnailProgressSnapshotVisibleCoalesceMs = 120;
         private const int ThumbnailProgressSnapshotFallbackIntervalMs = 3000;
         private static readonly TimeSpan ThumbnailProgressTransientRescueWorkerDuration =
             TimeSpan.FromSeconds(5);
@@ -37,7 +39,9 @@ namespace IndigoMovieManager
         private ThumbnailProgressTabPresenter _thumbnailProgressTabPresenter;
         // 進捗スナップショット更新要求はここで集約し、UI反映の連打を抑える。
         private int _thumbnailProgressSnapshotRefreshQueued;
+        private int _thumbnailProgressSnapshotRefreshDelayQueued;
         private int _thumbnailProgressSnapshotRefreshRequested;
+        private long _thumbnailProgressSnapshotRefreshNextAllowedUtcTicks;
         private long _thumbnailProgressLastAppliedSnapshotVersion = -1;
         private int _thumbnailProgressLastAppliedLogicalCoreCount = -1;
         private string _thumbnailProgressLastAppliedRescueWorkerSignature = "";
@@ -766,6 +770,13 @@ namespace IndigoMovieManager
             bool ShouldQueueFailureSync
         );
 
+        internal readonly record struct ThumbnailProgressSnapshotRefreshDecision(
+            bool ShouldQueueNow,
+            bool ShouldQueueDelayed,
+            TimeSpan Delay,
+            long NextAllowedUtcTicks
+        );
+
         private void ThumbnailProgressUiTimer_Tick(object sender, EventArgs e)
         {
             try
@@ -810,6 +821,33 @@ namespace IndigoMovieManager
             return new ThumbnailProgressUiTickBehavior(
                 ShouldRefreshUi: isThumbnailProgressTabVisibleOrSelected,
                 ShouldQueueFailureSync: true
+            );
+        }
+
+        // 表示中のイベントバーストは、最短間隔内なら遅延1本へ束ねてUI予約の雪崩を止める。
+        internal static ThumbnailProgressSnapshotRefreshDecision ResolveThumbnailProgressSnapshotRefreshDecision(
+            long nowUtcTicks,
+            long nextAllowedUtcTicks,
+            int coalesceMs
+        )
+        {
+            if (coalesceMs <= 0 || nextAllowedUtcTicks <= nowUtcTicks)
+            {
+                long nextAllowed =
+                    nowUtcTicks + TimeSpan.FromMilliseconds(Math.Max(0, coalesceMs)).Ticks;
+                return new ThumbnailProgressSnapshotRefreshDecision(
+                    ShouldQueueNow: true,
+                    ShouldQueueDelayed: false,
+                    Delay: TimeSpan.Zero,
+                    NextAllowedUtcTicks: nextAllowed
+                );
+            }
+
+            return new ThumbnailProgressSnapshotRefreshDecision(
+                ShouldQueueNow: false,
+                ShouldQueueDelayed: true,
+                Delay: TimeSpan.FromTicks(nextAllowedUtcTicks - nowUtcTicks),
+                NextAllowedUtcTicks: nextAllowedUtcTicks
             );
         }
 
@@ -1628,15 +1666,74 @@ namespace IndigoMovieManager
                 return;
             }
 
+            if (Interlocked.CompareExchange(ref _thumbnailProgressSnapshotRefreshQueued, 0, 0) == 1)
+            {
+                return;
+            }
+
+            long nowUtcTicks = DateTime.UtcNow.Ticks;
+            ThumbnailProgressSnapshotRefreshDecision decision =
+                ResolveThumbnailProgressSnapshotRefreshDecision(
+                    nowUtcTicks,
+                    Interlocked.Read(ref _thumbnailProgressSnapshotRefreshNextAllowedUtcTicks),
+                    ThumbnailProgressSnapshotVisibleCoalesceMs
+            );
+            if (decision.ShouldQueueDelayed)
+            {
+                QueueDelayedThumbnailProgressSnapshotRefresh(decision.Delay);
+                return;
+            }
+
             if (Interlocked.Exchange(ref _thumbnailProgressSnapshotRefreshQueued, 1) == 1)
             {
                 return;
             }
 
+            _ = Interlocked.Exchange(
+                ref _thumbnailProgressSnapshotRefreshNextAllowedUtcTicks,
+                decision.NextAllowedUtcTicks
+            );
             _ = Dispatcher.BeginInvoke(
                 DispatcherPriority.Background,
                 new Action(ProcessThumbnailProgressSnapshotRefreshQueue)
             );
+        }
+
+        private void QueueDelayedThumbnailProgressSnapshotRefresh(TimeSpan delay)
+        {
+            if (Interlocked.Exchange(ref _thumbnailProgressSnapshotRefreshDelayQueued, 1) == 1)
+            {
+                return;
+            }
+
+            _ = RunDelayedThumbnailProgressSnapshotRefreshAsync(delay);
+        }
+
+        private async Task RunDelayedThumbnailProgressSnapshotRefreshAsync(TimeSpan delay)
+        {
+            try
+            {
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugRuntimeLog.Write(
+                    "thumbnail-progress",
+                    $"delayed snapshot refresh failed: {ex.Message}"
+                );
+            }
+            finally
+            {
+                _ = Interlocked.Exchange(ref _thumbnailProgressSnapshotRefreshDelayQueued, 0);
+            }
+
+            if (Interlocked.CompareExchange(ref _thumbnailProgressSnapshotRefreshRequested, 0, 0) == 1)
+            {
+                RequestThumbnailProgressSnapshotRefresh();
+            }
         }
 
         private void ProcessThumbnailProgressSnapshotRefreshQueue()

--- a/Docs/forAI/Implementation Plan_UIを含む高速化のための抜本改善プラン_2026-04-17.md
+++ b/Docs/forAI/Implementation Plan_UIを含む高速化のための抜本改善プラン_2026-04-17.md
@@ -4,7 +4,10 @@
 
 変更概要:
 - watch query-only 局所更新が full reload へ戻る理由を `changed_path_fallback` で残し、局所更新が効かない条件を観測して次の縮小対象を選べるようにした
+- watch キュー圧縮の trigger / path 因果ログを追加し、圧縮で見えにくくなる発火理由を `debug-runtime.log` で追えるようにした
 - WebView Player 停止・切替時に `user-priority` 解放待ちを残さないよう、WebView surface リセットで pending 解放を畳む方針を反映した
+- サムネ進捗の初期 snapshot 全走査を背景化し、下部 `ThumbnailProgress` 初期化が first-page と入力を押しのけないようにした
+- 検索確定後の履歴保存・履歴再読込を背景化し、検索完了直後に残っていた同期 DB I/O を UI 導線から外した
 - 全体計画の再構築に合わせ、実行レーンを `UIスレッド簡素化`、`diff-first UI`、`watcher/poll 境界安定化`、`起動 warm path`、`visible-first / Player`、`skin 別レーン` の順へ整理した
 - `Watcher.cs` の薄化は独立目標から外し、UI thread / queue / shutdown の詰まりを減らす時だけ進める方針へ変更した
 - `fire-and-forget` の増加ではなく、bounded drain とログを持つ queue / persister / scheduler へ寄せることを固定した
@@ -45,6 +48,7 @@
 - さらに `manual-reload` 開始時に watch scan scope を進め、走行中の `Auto / Watch` scan を stale 扱いで早めに畳むようにした
 - さらにプレーヤータブ右側一覧の画像バインドは、active tab 判定だけでなく viewport の可視・近傍キーにも通し、再読込直後の off-screen `image cache hit` 雪崩を減らす方向へ寄せた
 - 下部 `ThumbnailProgress` タブが非表示の時は snapshot refresh を即時 UI 更新せず dirty 記録だけへ寄せ、サムネ成功直後の hidden progress 更新が `activity=None` を増やす経路を細くし始めた
+- 下部 `ThumbnailProgress` の初期 snapshot 全走査は UI 初期表示から外し、背景作成後に UI へ反映する形へ寄せた
 - `SearchSidecar` は本線リポから一旦外し、別リポで継続検証する方針へ切り替えた
 - 本線の検索 hot path は、sidecar を使わず既存 `SearchService` 正本のまま `MovieRecords` 単位 cache で軽量化する方針へ寄せた
 - 検索窓のインクリメント検索は、常時即時実行ではなく `0.5s debounce` で通常時だけ戻し、起動時部分ロード・IME変換中・途中構文では Enter 確定へ寄せる
@@ -54,6 +58,7 @@
 - さらに ASCII 検索では `Movie_Name / Movie_Path / Tags / Comment1-3 / Roma` だけを見る軽量投影 cache を使い、`kana / katakana` 派生列の全件生成を避けて `filter-movies` の詰まりを減らし始めた
 - 実機確認では `ggggg` のような ASCII 検索で `filter-movies` が完了しない事象を再現し、軽量投影 cache 追加後は検索完了まで進むことを確認した。ASCII 検索 hot path の主因は、比較順より `kana / katakana` 派生列の全件生成だったと整理する
 - さらに textbox 入力の重さは `SearchBox_TextChanged(...)` ごとの `RestartThumbnailTask()` 連打が主因だったため、通常入力中はサムネ常駐を再起動せず、実検索の瞬間だけ再起動する形へ寄せた
+- さらに検索確定後の履歴保存・履歴再読込は background task へ逃がし、DB が同じ時だけ UI へ履歴候補を反映する形へ寄せた
 - `UiHang` オーバーレイの終了時残留は、常時の無通信 timer を主解にせず、owner 付与、caller 側 hide 保証、overlay thread shutdown 強制線の順で解く方針を固定した。無通信 timer は shutdown 専用 safety fuse としてのみ扱う
 - `Watcher.cs` は入口と中盤の `watch table load failure`、`visible gate`、`scan strategy detail`、`full reconcile` 入口判定を helper / policy 側へ寄せ続け、`CheckFolderAsync(...)` を orchestration 専念へさらに寄せた
 - `Everything poll` は watch folder snapshot、eligible 判定再利用、重複 path 除去、low-update 時の間隔延長まで入り、通常周回の CPU / wakeup コストを下げ始めた
@@ -64,6 +69,7 @@
 - `WatcherEventQueue` は処理 task を 1 本共有し、enqueue ごとに queue runner を増やさない形へ寄せて watch burst 時の先頭詰まり増幅を抑えた
 - `Created` の ready 待機は queue runner から分離して直列専用パイプラインへ逃がし、`Renamed` を `Created` 待ちで止めない形へ整合を補強した
 - 旧パス未登録の `Renamed` は watch scan へ再合流させ、`Created -> Renamed` 連鎖で rename だけ先行した場合でも最終整合を回収する形へ寄せた
+- watch query-only full 戻り理由ログ、watch キュー圧縮の因果ログ、WebView 停止時の `user-priority` pending 解放、サムネ進捗初期全走査の背景化は完了済みとして扱う
 
 ## 1. 目的
 
@@ -229,7 +235,7 @@
 - `FileSystemWatcher` 入力停止、watch event queue complete、created ready pipeline drain、Everything poll 停止を順序付きで扱う。
 - low-update 時の poll interval 延長を、初期処理が落ち着いた後だけ有効化する。
 - `watch folder snapshot` と eligible 判定 cache の invalidation 条件を、DB 切替 / watch folder 編集 / settings 変更へ限定する。
-- queue の mode 圧縮で trigger / path の因果が消えすぎる箇所は、ログか軽量 DTO で追えるようにする。
+- queue の mode 圧縮で trigger / path の因果が消えすぎる箇所は、追加済みログを維持し、必要なら軽量 DTO へ広げる。
 
 完了条件:
 - shutdown 中に watcher / poll / created pipeline が新規要求を増やさない。
@@ -348,7 +354,7 @@
 ### Step 3
 
 - `FilterAndSortAsync(...)` の呼び出し元を、`full snapshot reload`、`query only recompute`、`item diff apply` の 3 群へ再分類する。
-- `changed paths + ChangeKind + DirtyFields + ObservedState` がある経路では、full reload へ戻る理由を必ず明示する。
+- `changed paths + ChangeKind + DirtyFields + ObservedState` がある経路では、追加済みの full reload 戻り理由ログを使い、残った fallback 条件を実機ログから選んで縮める。
 
 ### Step 4
 

--- a/Docs/forAI/Implementation Plan_UIを含む高速化のための抜本改善プラン_2026-04-17.md
+++ b/Docs/forAI/Implementation Plan_UIを含む高速化のための抜本改善プラン_2026-04-17.md
@@ -1,8 +1,10 @@
 # Implementation Plan UIを含む高速化のための抜本改善プラン 2026-04-17
 
-最終更新日: 2026-04-24
+最終更新日: 2026-04-27
 
 変更概要:
+- watch query-only 局所更新が full reload へ戻る理由を `changed_path_fallback` で残し、局所更新が効かない条件を観測して次の縮小対象を選べるようにした
+- WebView Player 停止・切替時に `user-priority` 解放待ちを残さないよう、WebView surface リセットで pending 解放を畳む方針を反映した
 - 全体計画の再構築に合わせ、実行レーンを `UIスレッド簡素化`、`diff-first UI`、`watcher/poll 境界安定化`、`起動 warm path`、`visible-first / Player`、`skin 別レーン` の順へ整理した
 - `Watcher.cs` の薄化は独立目標から外し、UI thread / queue / shutdown の詰まりを減らす時だけ進める方針へ変更した
 - `fire-and-forget` の増加ではなく、bounded drain とログを持つ queue / persister / scheduler へ寄せることを固定した

--- a/Tests/IndigoMovieManager.Tests/EverythingWatchPollPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/EverythingWatchPollPolicyTests.cs
@@ -157,6 +157,19 @@ public sealed class EverythingWatchPollPolicyTests
     }
 
     [Test]
+    public void ShouldDeferEverythingWatchPollForUserPriority_検索優先中だけTrueを返す()
+    {
+        Assert.That(
+            MainWindow.ShouldDeferEverythingWatchPollForUserPriority(isUserPriorityActive: true),
+            Is.True
+        );
+        Assert.That(
+            MainWindow.ShouldDeferEverythingWatchPollForUserPriority(isUserPriorityActive: false),
+            Is.False
+        );
+    }
+
+    [Test]
     public void ShouldRunEverythingWatchPoll_eligibleなwatchがあれば動かす()
     {
         string dbPath = System.IO.Path.GetTempFileName();

--- a/Tests/IndigoMovieManager.Tests/EverythingWatchPollPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/EverythingWatchPollPolicyTests.cs
@@ -170,6 +170,84 @@ public sealed class EverythingWatchPollPolicyTests
     }
 
     [Test]
+    public void ShouldProbeEverythingWatchPollQueueLoad_poll延期中はFalseを返す()
+    {
+        Assert.That(
+            MainWindow.ShouldProbeEverythingWatchPollQueueLoad(
+                isDeferredByUiSuppression: true,
+                isDeferredByUserPriority: false
+            ),
+            Is.False
+        );
+        Assert.That(
+            MainWindow.ShouldProbeEverythingWatchPollQueueLoad(
+                isDeferredByUiSuppression: false,
+                isDeferredByUserPriority: true
+            ),
+            Is.False
+        );
+        Assert.That(
+            MainWindow.ShouldProbeEverythingWatchPollQueueLoad(
+                isDeferredByUiSuppression: false,
+                isDeferredByUserPriority: false
+            ),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void ApplyEverythingWatchPollInteractionDelayPolicy_通常時は遅延を変えない()
+    {
+        int delayMs = MainWindow.ApplyEverythingWatchPollInteractionDelayPolicy(
+            delayMs: 3000,
+            isDeferredByUiSuppression: false,
+            isDeferredByUserPriority: false,
+            isPlayerPlaybackActive: false
+        );
+
+        Assert.That(delayMs, Is.EqualTo(3000));
+    }
+
+    [Test]
+    public void ApplyEverythingWatchPollInteractionDelayPolicy_UI操作中はcalm間隔まで延長する()
+    {
+        int delayMs = MainWindow.ApplyEverythingWatchPollInteractionDelayPolicy(
+            delayMs: 3000,
+            isDeferredByUiSuppression: true,
+            isDeferredByUserPriority: false,
+            isPlayerPlaybackActive: false
+        );
+
+        Assert.That(delayMs, Is.EqualTo(9000));
+    }
+
+    [Test]
+    public void ApplyEverythingWatchPollInteractionDelayPolicy_再生中はcalm間隔まで延長する()
+    {
+        int delayMs = MainWindow.ApplyEverythingWatchPollInteractionDelayPolicy(
+            delayMs: 3000,
+            isDeferredByUiSuppression: false,
+            isDeferredByUserPriority: false,
+            isPlayerPlaybackActive: true
+        );
+
+        Assert.That(delayMs, Is.EqualTo(9000));
+    }
+
+    [Test]
+    public void ApplyEverythingWatchPollInteractionDelayPolicy_既に長い遅延は維持する()
+    {
+        int delayMs = MainWindow.ApplyEverythingWatchPollInteractionDelayPolicy(
+            delayMs: 15000,
+            isDeferredByUiSuppression: false,
+            isDeferredByUserPriority: true,
+            isPlayerPlaybackActive: true
+        );
+
+        Assert.That(delayMs, Is.EqualTo(15000));
+    }
+
+    [Test]
     public void ShouldRunEverythingWatchPoll_eligibleなwatchがあれば動かす()
     {
         string dbPath = System.IO.Path.GetTempFileName();

--- a/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
@@ -25,6 +25,28 @@ public sealed class MainWindowFilterSortExecutionPolicyTests
         Assert.That(actual, Is.EqualTo(expected));
     }
 
+    [TestCase(false, false, false, "no-snapshot-startup-partial")]
+    [TestCase(false, true, false, "none")]
+    [TestCase(true, false, false, "none")]
+    [TestCase(true, true, false, "none")]
+    [TestCase(false, false, true, "is-get-new")]
+    [TestCase(true, true, true, "is-get-new")]
+    public void ResolveFilterSortFullReloadReason_full_reload理由を短い札で返せる(
+        bool hasSnapshotData,
+        bool startupFeedLoadedAllPages,
+        bool isGetNew,
+        string expected
+    )
+    {
+        string actual = MainWindow.ResolveFilterSortFullReloadReason(
+            hasSnapshotData,
+            startupFeedLoadedAllPages,
+            isGetNew
+        );
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
     [TestCase(-1, false)]
     [TestCase(0, false)]
     [TestCase(1, false)]
@@ -50,6 +72,9 @@ public sealed class MainWindowFilterSortExecutionPolicyTests
 
         Assert.That(searchSource, Does.Contain("public async Task ApplySearchKeywordFromLinkAsync("));
         Assert.That(searchSource, Does.Contain("SearchExecutor.ExecuteAsync(keyword ?? \"\", syncSearchText: true)"));
+        Assert.That(searchSource, Does.Contain("if (SearchBox != null && !SearchBox.IsKeyboardFocusWithin)"));
+        Assert.That(searchSource, Does.Contain("catch (Exception ex)"));
+        Assert.That(searchSource, Does.Contain("link search failed:"));
         Assert.That(tagSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(keyword);"));
         Assert.That(detailSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(quoted);"));
         Assert.That(detailSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(mv.Ext);"));

--- a/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
@@ -84,6 +84,29 @@ public sealed class MainWindowFilterSortExecutionPolicyTests
         Assert.That(bookmarkSource, Does.Not.Contain("ownerWindow.SearchBox.Text ="));
     }
 
+    [Test]
+    public void SearchHistory_検索確定後のDB読み書きは背景へ逃がす()
+    {
+        string searchSource = GetRepoText("Views", "Main", "MainWindow.Search.cs");
+        string persistMethod = GetMethodBlock(
+            searchSource,
+            "private void PersistSearchHistoryAfterSearch("
+        );
+        string refreshMethod = GetMethodBlock(searchSource, "private void QueueSearchHistoryRefresh(");
+        string lostFocusMethod = GetMethodBlock(searchSource, "private void SearchBox_LostFocus(");
+
+        Assert.That(persistMethod, Does.Not.Contain("SearchHistoryService.PersistSuccessfulSearch("));
+        Assert.That(persistMethod, Does.Not.Contain("GetHistoryTable("));
+        Assert.That(persistMethod, Does.Contain("QueueSearchHistoryRefresh("));
+        Assert.That(refreshMethod, Does.Contain("Task.Run("));
+        Assert.That(refreshMethod, Does.Contain("SearchHistoryService.PersistSuccessfulSearch("));
+        Assert.That(refreshMethod, Does.Contain("SearchHistoryService.LoadLatestHistory("));
+        Assert.That(refreshMethod, Does.Contain("Dispatcher.BeginInvoke("));
+        Assert.That(refreshMethod, Does.Contain("AreSameMainDbPath("));
+        Assert.That(lostFocusMethod, Does.Contain("QueueSearchHistoryUsageRecord("));
+        Assert.That(lostFocusMethod, Does.Not.Contain("SearchHistoryService.RecordSearchUsage("));
+    }
+
     private static string GetRepoText(params string[] relativePathParts)
     {
         DirectoryInfo? current = new(TestContext.CurrentContext.TestDirectory);
@@ -99,6 +122,35 @@ public sealed class MainWindowFilterSortExecutionPolicyTests
         }
 
         Assert.Fail($"Repository file not found: {Path.Combine(relativePathParts)}");
+        return "";
+    }
+
+    private static string GetMethodBlock(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0), $"{signature} が見つかりません。");
+
+        int bodyStart = source.IndexOf('{', start);
+        Assert.That(bodyStart, Is.GreaterThanOrEqualTo(0), $"{signature} の本文開始が見つかりません。");
+
+        int depth = 0;
+        for (int index = bodyStart; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, index - start + 1);
+                }
+            }
+        }
+
+        Assert.Fail($"{signature} の本文終了が見つかりません。");
         return "";
     }
 }

--- a/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
@@ -46,14 +46,17 @@ public sealed class MainWindowFilterSortExecutionPolicyTests
         string searchSource = GetRepoText("Views", "Main", "MainWindow.Search.cs");
         string tagSource = GetRepoText("UserControls", "TagControl.xaml.cs");
         string detailSource = GetRepoText("UserControls", "ExtDetail.xaml.cs");
+        string bookmarkSource = GetRepoText("UserControls", "Bookmark.xaml.cs");
 
         Assert.That(searchSource, Does.Contain("public async Task ApplySearchKeywordFromLinkAsync("));
         Assert.That(searchSource, Does.Contain("SearchExecutor.ExecuteAsync(keyword ?? \"\", syncSearchText: true)"));
         Assert.That(tagSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(keyword);"));
         Assert.That(detailSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(quoted);"));
         Assert.That(detailSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(mv.Ext);"));
+        Assert.That(bookmarkSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(mv.Movie_Body ?? \"\");"));
         Assert.That(tagSource, Does.Not.Contain("FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);"));
         Assert.That(detailSource, Does.Not.Contain("FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);"));
+        Assert.That(bookmarkSource, Does.Not.Contain("ownerWindow.SearchBox.Text ="));
     }
 
     private static string GetRepoText(params string[] relativePathParts)

--- a/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/MainWindowFilterSortExecutionPolicyTests.cs
@@ -39,4 +39,38 @@ public sealed class MainWindowFilterSortExecutionPolicyTests
         bool actual = MainWindow.ShouldRunFilterSortOnBackground(sourceCount);
         Assert.That(actual, Is.EqualTo(expected));
     }
+
+    [Test]
+    public void LinkSearch_ユーザーコントロールから検索正本へ合流する()
+    {
+        string searchSource = GetRepoText("Views", "Main", "MainWindow.Search.cs");
+        string tagSource = GetRepoText("UserControls", "TagControl.xaml.cs");
+        string detailSource = GetRepoText("UserControls", "ExtDetail.xaml.cs");
+
+        Assert.That(searchSource, Does.Contain("public async Task ApplySearchKeywordFromLinkAsync("));
+        Assert.That(searchSource, Does.Contain("SearchExecutor.ExecuteAsync(keyword ?? \"\", syncSearchText: true)"));
+        Assert.That(tagSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(keyword);"));
+        Assert.That(detailSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(quoted);"));
+        Assert.That(detailSource, Does.Contain("await ownerWindow.ApplySearchKeywordFromLinkAsync(mv.Ext);"));
+        Assert.That(tagSource, Does.Not.Contain("FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);"));
+        Assert.That(detailSource, Does.Not.Contain("FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);"));
+    }
+
+    private static string GetRepoText(params string[] relativePathParts)
+    {
+        DirectoryInfo? current = new(TestContext.CurrentContext.TestDirectory);
+        while (current != null)
+        {
+            string candidate = Path.Combine([current.FullName, .. relativePathParts]);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            current = current.Parent;
+        }
+
+        Assert.Fail($"Repository file not found: {Path.Combine(relativePathParts)}");
+        return "";
+    }
 }

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -172,6 +172,11 @@ public sealed class ManualPlayerResizeHookPolicyTests
             upperTabPlayerSource,
             Does.Contain("if (ReferenceEquals(list.SelectedItem, record))")
         );
+        Assert.That(upperTabPlayerSource, Does.Contain("bool activeListSelectionChanged = false;"));
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("if (activeListSelectionChanged)")
+        );
         Assert.That(
             upperTabPlayerSource,
             Does.Contain("if (!ReferenceEquals(list.SelectedItem, selectedMovie))")
@@ -192,14 +197,48 @@ public sealed class ManualPlayerResizeHookPolicyTests
     }
 
     [Test]
+    public void PlayerDispatcherBackgroundWait_同時待機は1本へ畳む()
+    {
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("private DispatcherOperation _playerBackgroundYieldOperation;")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("private async Task WaitForPlayerDispatcherBackgroundAsync()")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("pendingOperation = Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("_playerBackgroundYieldOperation = pendingOperation;")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("await WaitForPlayerDispatcherBackgroundAsync();")
+        );
+    }
+
+    [Test]
     public void OpenMovieInPlayerTabAsync_Player操作中はuser_priority_scopeで囲む()
     {
         // Player 再生開始中は watch/poll を後ろへ逃がし、早期 return でも必ず解除する。
         string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+        string mainWindowPlayerSource = GetMainWindowPlayerSourceText();
+        string mainWindowXaml = GetRepoText("Views", "Main", "MainWindow.xaml");
 
         Assert.That(upperTabPlayerSource, Does.Contain("BeginUserPriorityWork(\"player\");"));
         Assert.That(upperTabPlayerSource, Does.Contain("MarkPlayerUserPriorityReleasePending();"));
         Assert.That(upperTabPlayerSource, Does.Contain("ReleasePendingPlayerUserPriorityWork();"));
+        Assert.That(upperTabPlayerSource, Does.Contain("if (!e.IsSuccess || !_isWebViewPlayerActive)"));
+        Assert.That(upperTabPlayerSource, Does.Contain("_hasPendingWebViewPlaybackRequest = false;"));
+        Assert.That(mainWindowXaml, Does.Contain("MediaFailed=\"UxVideoPlayer_MediaFailed\""));
+        Assert.That(mainWindowPlayerSource, Does.Contain("private void UxVideoPlayer_MediaFailed("));
+        Assert.That(mainWindowPlayerSource, Does.Contain("_hasPendingPlayerPlaybackRequest = false;"));
         Assert.That(upperTabPlayerSource, Does.Contain("try"));
         Assert.That(upperTabPlayerSource, Does.Contain("finally"));
         Assert.That(upperTabPlayerSource, Does.Contain("EndUserPriorityWork(\"player\");"));

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -45,15 +45,14 @@ public sealed class ManualPlayerResizeHookPolicyTests
     }
 
     [Test]
-    public void PlayerVolume_保存値が0へリセットされた時だけ起動時に50へ戻す()
+    public void PlayerVolume_保存値が0または100へリセットされた時は起動時に50へ戻す()
     {
         string playerSource = GetMainWindowPlayerSourceText();
         string windowSource = GetRepoText("Views", "Main", "MainWindow.xaml.cs");
 
         Assert.That(playerSource, Does.Contain("private const double DefaultPlayerVolume = 0.5d;"));
         Assert.That(playerSource, Does.Contain("private static double ResolveSavedPlayerVolumeSetting(double volume)"));
-        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;"));
-        Assert.That(playerSource, Does.Not.Contain("resolvedVolume >= 1d"));
+        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d || resolvedVolume >= 1d"));
         Assert.That(
             windowSource,
             Does.Contain("ResolveSavedPlayerVolumeSetting(Properties.Settings.Default.PlayerVolume)")
@@ -70,11 +69,27 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(mainWindowPlayerSource, Does.Contain("indigoPlayerHostVolumeApplied = '1'"));
         Assert.That(upperTabPlayerSource, Does.Contain("indigoPlayerHostVolumeApplied = '1'"));
         Assert.That(fullscreenWindowSource, Does.Contain("indigoPlayerHostVolumeApplied = '1'"));
+        Assert.That(mainWindowPlayerSource, Does.Contain("indigoPlayerHostVolumeApplying = '1'"));
+        Assert.That(upperTabPlayerSource, Does.Contain("indigoPlayerHostVolumeApplying = '1'"));
         Assert.That(
             upperTabPlayerSource,
             Does.Contain("player.dataset.indigoPlayerHostVolumeApplied !== '1'")
         );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("player.dataset.indigoPlayerHostVolumeApplying === '1'")
+        );
         Assert.That(upperTabPlayerSource, Does.Not.Contain("notifyVolume();"));
+    }
+
+    [Test]
+    public void WebViewPlayer_動画切り替え時の100パーセント通知は保存しない()
+    {
+        string playerSource = GetMainWindowPlayerSourceText();
+
+        Assert.That(playerSource, Does.Contain("if (resolvedVolume >= 1d && currentVolume < 0.999d)"));
+        Assert.That(playerSource, Does.Contain("player webview default volume ignored"));
+        Assert.That(playerSource, Does.Contain("return;"));
     }
 
     [Test]

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -37,6 +37,10 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(source, Does.Contain("private DispatcherTimer _playerVolumeSaveDebounceTimer;"));
         Assert.That(source, Does.Contain("private void QueuePlayerVolumeSettingSave()"));
         Assert.That(source, Does.Contain("private void PlayerVolumeSaveDebounceTimer_Tick("));
+        Assert.That(
+            source,
+            Does.Contain("Math.Abs(Properties.Settings.Default.PlayerVolume - resolvedVolume) > 0.0001d")
+        );
         Assert.That(source, Does.Contain("QueuePlayerVolumeSettingSave();"));
     }
 

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -249,6 +249,41 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(upperTabPlayerSource, Does.Contain("EndUserPriorityWork(\"player\");"));
     }
 
+    [Test]
+    public void ResetWebViewPlayerSurface_WebView停止時もpending_user_priorityを解除する()
+    {
+        // WebView の NavigationCompleted が後着しても、reset 側で優先区間を確実に畳む。
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+        string resetMethod = GetMethodBlock(
+            upperTabPlayerSource,
+            "private void ResetWebViewPlayerSurface()"
+        );
+        string openMovieMethod = GetMethodBlock(
+            upperTabPlayerSource,
+            "private async Task OpenMovieInPlayerTabAsync("
+        );
+
+        int webViewActiveCheckIndex = openMovieMethod.IndexOf(
+            "if (_isWebViewPlayerActive)",
+            StringComparison.Ordinal
+        );
+        int resetCallIndex = openMovieMethod.IndexOf(
+            "ResetWebViewPlayerSurface();",
+            StringComparison.Ordinal
+        );
+
+        Assert.That(webViewActiveCheckIndex, Is.GreaterThanOrEqualTo(0));
+        Assert.That(resetCallIndex, Is.GreaterThan(webViewActiveCheckIndex));
+        Assert.That(resetMethod, Does.Contain("_hasPendingWebViewPlaybackRequest = false;"));
+        Assert.That(resetMethod, Does.Contain("_isWebViewPlayerActive = false;"));
+        Assert.That(resetMethod, Does.Contain("_pendingWebViewNavigationId = 0;"));
+        Assert.That(resetMethod, Does.Contain("ReleasePendingPlayerUserPriorityWork();"));
+        Assert.That(
+            resetMethod.IndexOf("ReleasePendingPlayerUserPriorityWork();", StringComparison.Ordinal),
+            Is.LessThan(resetMethod.IndexOf("if (uxWebVideoPlayer == null)", StringComparison.Ordinal))
+        );
+    }
+
     private static string GetMainWindowPlayerSourceText()
     {
         return GetRepoText("Views", "Main", "MainWindow.Player.cs");
@@ -284,6 +319,35 @@ public sealed class ManualPlayerResizeHookPolicyTests
         }
 
         Assert.Fail($"{Path.Combine(relativePathParts)} の位置を repo root から解決できませんでした。");
+        return string.Empty;
+    }
+
+    private static string GetMethodBlock(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0), $"{signature} が見つかりません。");
+
+        int bodyStart = source.IndexOf('{', start);
+        Assert.That(bodyStart, Is.GreaterThanOrEqualTo(0), $"{signature} の本文開始が見つかりません。");
+
+        int depth = 0;
+        for (int index = bodyStart; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, index - start + 1);
+                }
+            }
+        }
+
+        Assert.Fail($"{signature} の本文終了が見つかりません。");
         return string.Empty;
     }
 }

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -45,14 +45,15 @@ public sealed class ManualPlayerResizeHookPolicyTests
     }
 
     [Test]
-    public void PlayerVolume_保存値が0または100へリセットされた時は起動時に50へ戻す()
+    public void PlayerVolume_保存値が0へリセットされた時だけ起動時に50へ戻す()
     {
         string playerSource = GetMainWindowPlayerSourceText();
         string windowSource = GetRepoText("Views", "Main", "MainWindow.xaml.cs");
 
         Assert.That(playerSource, Does.Contain("private const double DefaultPlayerVolume = 0.5d;"));
         Assert.That(playerSource, Does.Contain("private static double ResolveSavedPlayerVolumeSetting(double volume)"));
-        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d || resolvedVolume >= 1d"));
+        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;"));
+        Assert.That(playerSource, Does.Not.Contain("resolvedVolume >= 1d"));
         Assert.That(
             windowSource,
             Does.Contain("ResolveSavedPlayerVolumeSetting(Properties.Settings.Default.PlayerVolume)")
@@ -110,6 +111,36 @@ public sealed class ManualPlayerResizeHookPolicyTests
         );
         Assert.That(upperTabPlayerSource, Does.Contain("return;"));
         Assert.That(upperTabPlayerSource, Does.Contain("GetUpperTabPlayerList()?.ScrollIntoView(selectedMovie);"));
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("RequestUpperTabVisibleRangeRefresh(immediate: true, reason: \"player-view-mode\");")
+        );
+    }
+
+    [Test]
+    public void PlayerThumbnailSelectionSync_同一選択では再スクロールとvisible更新を積まない()
+    {
+        // プレイヤータブ内の同一動画再生では、選択同期だけで重い visible refresh を再投入しない。
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("private bool SelectUpperTabPlayerMovieRecord(MovieRecords record)")
+        );
+        Assert.That(upperTabPlayerSource, Does.Contain("bool selectionChanged = false;"));
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("if (ReferenceEquals(list.SelectedItem, record))")
+        );
+        Assert.That(upperTabPlayerSource, Does.Contain("return selectionChanged;"));
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("selectionChanged = SelectUpperTabPlayerMovieRecord(record);")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("if (selectionChanged)")
+        );
         Assert.That(
             upperTabPlayerSource,
             Does.Contain("RequestUpperTabVisibleRangeRefresh(immediate: true, reason: \"player-view-mode\");")

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -147,6 +147,18 @@ public sealed class ManualPlayerResizeHookPolicyTests
         );
     }
 
+    [Test]
+    public void OpenMovieInPlayerTabAsync_Player操作中はuser_priority_scopeで囲む()
+    {
+        // Player 再生開始中は watch/poll を後ろへ逃がし、早期 return でも必ず解除する。
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+
+        Assert.That(upperTabPlayerSource, Does.Contain("BeginUserPriorityWork(\"player\");"));
+        Assert.That(upperTabPlayerSource, Does.Contain("try"));
+        Assert.That(upperTabPlayerSource, Does.Contain("finally"));
+        Assert.That(upperTabPlayerSource, Does.Contain("EndUserPriorityWork(\"player\");"));
+    }
+
     private static string GetMainWindowPlayerSourceText()
     {
         return GetRepoText("Views", "Main", "MainWindow.Player.cs");

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -41,14 +41,14 @@ public sealed class ManualPlayerResizeHookPolicyTests
     }
 
     [Test]
-    public void PlayerVolume_保存値リセット時は起動時に50へ戻す()
+    public void PlayerVolume_保存値が0または100へリセットされた時は起動時に50へ戻す()
     {
         string playerSource = GetMainWindowPlayerSourceText();
         string windowSource = GetRepoText("Views", "Main", "MainWindow.xaml.cs");
 
         Assert.That(playerSource, Does.Contain("private const double DefaultPlayerVolume = 0.5d;"));
         Assert.That(playerSource, Does.Contain("private static double ResolveSavedPlayerVolumeSetting(double volume)"));
-        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;"));
+        Assert.That(playerSource, Does.Contain("return resolvedVolume <= 0d || resolvedVolume >= 1d"));
         Assert.That(
             windowSource,
             Does.Contain("ResolveSavedPlayerVolumeSetting(Properties.Settings.Default.PlayerVolume)")

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -234,10 +234,15 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(upperTabPlayerSource, Does.Contain("BeginUserPriorityWork(\"player\");"));
         Assert.That(upperTabPlayerSource, Does.Contain("MarkPlayerUserPriorityReleasePending();"));
         Assert.That(upperTabPlayerSource, Does.Contain("ReleasePendingPlayerUserPriorityWork();"));
-        Assert.That(upperTabPlayerSource, Does.Contain("if (!e.IsSuccess || !_isWebViewPlayerActive)"));
+        Assert.That(upperTabPlayerSource, Does.Contain("if (!e.IsSuccess)"));
+        Assert.That(mainWindowXaml, Does.Contain("MediaEnded=\"UxVideoPlayer_MediaEnded\""));
         Assert.That(upperTabPlayerSource, Does.Contain("_hasPendingWebViewPlaybackRequest = false;"));
+        Assert.That(mainWindowXaml, Does.Contain("NavigationStarting=\"UxWebVideoPlayer_NavigationStarting\""));
+        Assert.That(upperTabPlayerSource, Does.Contain("e.NavigationId != _pendingWebViewNavigationId"));
         Assert.That(mainWindowXaml, Does.Contain("MediaFailed=\"UxVideoPlayer_MediaFailed\""));
         Assert.That(mainWindowPlayerSource, Does.Contain("private void UxVideoPlayer_MediaFailed("));
+        Assert.That(mainWindowPlayerSource, Does.Contain("private void UxVideoPlayer_MediaEnded("));
+        Assert.That(mainWindowPlayerSource, Does.Contain("IsPlaying = false;"));
         Assert.That(mainWindowPlayerSource, Does.Contain("_hasPendingPlayerPlaybackRequest = false;"));
         Assert.That(upperTabPlayerSource, Does.Contain("try"));
         Assert.That(upperTabPlayerSource, Does.Contain("finally"));

--- a/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ManualPlayerResizeHookPolicyTests.cs
@@ -91,6 +91,10 @@ public sealed class ManualPlayerResizeHookPolicyTests
         );
         Assert.That(selectionSource, Does.Contain("_suppressPlayerThumbnailSelectionChanged = true;"));
         Assert.That(selectionSource, Does.Contain("SyncPlayerThumbnailSelectionAcrossViews(sourceList, record);"));
+        Assert.That(
+            selectionSource,
+            Does.Contain("if (!ReferenceEquals(sourceList.SelectedItem, record))")
+        );
         Assert.That(selectionSource, Does.Contain("ShowExtensionDetail(record);"));
         Assert.That(selectionSource, Does.Contain("ShowTagEditor(record);"));
 
@@ -118,6 +122,42 @@ public sealed class ManualPlayerResizeHookPolicyTests
     }
 
     [Test]
+    public void PlayerSurface_同一表示状態とサイズは再代入しない()
+    {
+        string mainWindowPlayerSource = GetMainWindowPlayerSourceText();
+        string upperTabPlayerSource = GetUpperTabPlayerSourceText();
+
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("private static void SetPlayerVisibilityIfChanged(UIElement element, Visibility visibility)")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("element == null || element.Visibility == visibility")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("SetPlayerVisibilityIfChanged(PlayerArea, Visibility.Visible);")
+        );
+        Assert.That(
+            mainWindowPlayerSource,
+            Does.Contain("private static void SetPlayerElementSizeIfChanged(")
+        );
+        Assert.That(
+            mainWindowPlayerSource,
+            Does.Contain("ArePlayerLayoutLengthsEqual(element.Width, width)")
+        );
+        Assert.That(
+            mainWindowPlayerSource,
+            Does.Contain("ArePlayerLayoutLengthsEqual(element.Height, height)")
+        );
+        Assert.That(
+            mainWindowPlayerSource,
+            Does.Contain("double.IsNaN(current) && double.IsNaN(next)")
+        );
+    }
+
+    [Test]
     public void PlayerThumbnailSelectionSync_同一選択では再スクロールとvisible更新を積まない()
     {
         // プレイヤータブ内の同一動画再生では、選択同期だけで重い visible refresh を再投入しない。
@@ -131,6 +171,10 @@ public sealed class ManualPlayerResizeHookPolicyTests
         Assert.That(
             upperTabPlayerSource,
             Does.Contain("if (ReferenceEquals(list.SelectedItem, record))")
+        );
+        Assert.That(
+            upperTabPlayerSource,
+            Does.Contain("if (!ReferenceEquals(list.SelectedItem, selectedMovie))")
         );
         Assert.That(upperTabPlayerSource, Does.Contain("return selectionChanged;"));
         Assert.That(
@@ -154,6 +198,8 @@ public sealed class ManualPlayerResizeHookPolicyTests
         string upperTabPlayerSource = GetUpperTabPlayerSourceText();
 
         Assert.That(upperTabPlayerSource, Does.Contain("BeginUserPriorityWork(\"player\");"));
+        Assert.That(upperTabPlayerSource, Does.Contain("MarkPlayerUserPriorityReleasePending();"));
+        Assert.That(upperTabPlayerSource, Does.Contain("ReleasePendingPlayerUserPriorityWork();"));
         Assert.That(upperTabPlayerSource, Does.Contain("try"));
         Assert.That(upperTabPlayerSource, Does.Contain("finally"));
         Assert.That(upperTabPlayerSource, Does.Contain("EndUserPriorityWork(\"player\");"));

--- a/Tests/IndigoMovieManager.Tests/MissingThumbnailRescuePolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/MissingThumbnailRescuePolicyTests.cs
@@ -1184,6 +1184,20 @@ public sealed class MissingThumbnailRescuePolicyTests
     }
 
     [Test]
+    public void ShowThumbnailUserActionPopup_背景スレッドから同期InvokeでUI完了待ちしない()
+    {
+        string source = GetRepoText("Thumbnail", "MainWindow.ThumbnailUserActionContext.cs");
+        string popupMethod = GetMethodBlock(
+            source,
+            "private void ShowThumbnailUserActionPopup("
+        );
+
+        Assert.That(popupMethod, Does.Not.Contain("Dispatcher.Invoke("));
+        Assert.That(popupMethod, Does.Contain("PostThumbnailUserActionUiNotification(showPopup);"));
+        Assert.That(popupMethod, Does.Contain("PostThumbnailUserActionUiNotification(showOverlay);"));
+    }
+
+    [Test]
     public void BuildThumbnailProgressRescueLaunchObservationText_一時優先の待機付き要求は優先起動表示になる()
     {
         string result = MainWindow.BuildThumbnailProgressRescueLaunchObservationText(
@@ -1444,5 +1458,52 @@ public sealed class MissingThumbnailRescuePolicyTests
         PropertyInfo property = exceptionType.GetProperty("FailureReason")!;
         property.SetValue(exception, failureReason);
         return (Exception)exception;
+    }
+
+    private static string GetRepoText(params string[] relativePathParts)
+    {
+        DirectoryInfo directory = new(TestContext.CurrentContext.TestDirectory);
+        while (directory != null)
+        {
+            string candidate = Path.Combine([directory.FullName, .. relativePathParts]);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail($"{Path.Combine(relativePathParts)} の位置を repo root から解決できませんでした。");
+        return string.Empty;
+    }
+
+    private static string GetMethodBlock(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0), $"{signature} が見つかりません。");
+
+        int bodyStart = source.IndexOf('{', start);
+        Assert.That(bodyStart, Is.GreaterThanOrEqualTo(0), $"{signature} の本文開始が見つかりません。");
+
+        int depth = 0;
+        for (int index = bodyStart; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, index - start + 1);
+                }
+            }
+        }
+
+        Assert.Fail($"{signature} の本文終了が見つかりません。");
+        return string.Empty;
     }
 }

--- a/Tests/IndigoMovieManager.Tests/MissingThumbnailRescuePolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/MissingThumbnailRescuePolicyTests.cs
@@ -793,6 +793,46 @@ public sealed class MissingThumbnailRescuePolicyTests
     }
 
     [Test]
+    public void ResolveThumbnailProgressSnapshotRefreshDecision_許可時刻を過ぎていれば即時予約する()
+    {
+        long nowTicks = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc).Ticks;
+
+        MainWindow.ThumbnailProgressSnapshotRefreshDecision result =
+            MainWindow.ResolveThumbnailProgressSnapshotRefreshDecision(
+                nowTicks,
+                nextAllowedUtcTicks: nowTicks - TimeSpan.FromMilliseconds(1).Ticks,
+                coalesceMs: 120
+            );
+
+        Assert.That(result.ShouldQueueNow, Is.True);
+        Assert.That(result.ShouldQueueDelayed, Is.False);
+        Assert.That(result.Delay, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(
+            result.NextAllowedUtcTicks,
+            Is.EqualTo(nowTicks + TimeSpan.FromMilliseconds(120).Ticks)
+        );
+    }
+
+    [Test]
+    public void ResolveThumbnailProgressSnapshotRefreshDecision_間隔内イベントは遅延1本へ寄せる()
+    {
+        long nowTicks = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc).Ticks;
+        long nextAllowedTicks = nowTicks + TimeSpan.FromMilliseconds(80).Ticks;
+
+        MainWindow.ThumbnailProgressSnapshotRefreshDecision result =
+            MainWindow.ResolveThumbnailProgressSnapshotRefreshDecision(
+                nowTicks,
+                nextAllowedTicks,
+                coalesceMs: 120
+            );
+
+        Assert.That(result.ShouldQueueNow, Is.False);
+        Assert.That(result.ShouldQueueDelayed, Is.True);
+        Assert.That(result.Delay, Is.EqualTo(TimeSpan.FromMilliseconds(80)));
+        Assert.That(result.NextAllowedUtcTicks, Is.EqualTo(nextAllowedTicks));
+    }
+
+    [Test]
     public void ShouldDeferThumbnailRescueWorkerLaunch_通常救済はbusy中なら待機する()
     {
         bool result = MainWindow.ShouldDeferThumbnailRescueWorkerLaunch(

--- a/Tests/IndigoMovieManager.Tests/ThumbnailProgressRuntimeTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ThumbnailProgressRuntimeTests.cs
@@ -199,6 +199,22 @@ public class ThumbnailProgressRuntimeTests
     }
 
     [Test]
+    public void ApplyInitialTotalCreatedCount_セッション進捗を保ったまま総作成数だけ後追い反映する()
+    {
+        ThumbnailProgressRuntime runtime = new();
+        runtime.UpdateSessionProgress(completedCount: 2, totalCount: 8, currentParallel: 1, configuredParallel: 4);
+
+        runtime.ApplyInitialTotalCreatedCount(123);
+
+        ThumbnailProgressRuntimeSnapshot snapshot = runtime.CreateSnapshot();
+        Assert.That(snapshot.TotalCreatedCount, Is.EqualTo(123));
+        Assert.That(snapshot.SessionCompletedCount, Is.EqualTo(2));
+        Assert.That(snapshot.SessionTotalCount, Is.EqualTo(8));
+        Assert.That(snapshot.CurrentParallelism, Is.EqualTo(1));
+        Assert.That(snapshot.ConfiguredParallelism, Is.EqualTo(4));
+    }
+
+    [Test]
     public void CreateSnapshot_無変更時は同一インスタンスを再利用する()
     {
         ThumbnailProgressRuntime runtime = new();

--- a/Tests/IndigoMovieManager.Tests/ThumbnailProgressRuntimeTests.cs
+++ b/Tests/IndigoMovieManager.Tests/ThumbnailProgressRuntimeTests.cs
@@ -215,6 +215,18 @@ public class ThumbnailProgressRuntimeTests
     }
 
     [Test]
+    public void ApplyInitialTotalCreatedCount_背景走査中の作成済み加算を保持する()
+    {
+        ThumbnailProgressRuntime runtime = new();
+        runtime.RecordThumbnailCreated(2);
+
+        runtime.ApplyInitialTotalCreatedCount(123);
+
+        ThumbnailProgressRuntimeSnapshot snapshot = runtime.CreateSnapshot();
+        Assert.That(snapshot.TotalCreatedCount, Is.EqualTo(125));
+    }
+
+    [Test]
     public void CreateSnapshot_無変更時は同一インスタンスを再利用する()
     {
         ThumbnailProgressRuntime runtime = new();

--- a/Tests/IndigoMovieManager.Tests/WatchCheckFolderQueueRuntimeTests.cs
+++ b/Tests/IndigoMovieManager.Tests/WatchCheckFolderQueueRuntimeTests.cs
@@ -1,0 +1,52 @@
+using IndigoMovieManager;
+using System.Reflection;
+
+namespace IndigoMovieManager.Tests;
+
+[TestFixture]
+public sealed class WatchCheckFolderQueueRuntimeTests
+{
+    [Test]
+    public void BuildWatchCheckFolderQueueTraceSummary_path由来と圧縮回数を短く返す()
+    {
+        string result = InvokePrivateStaticString(
+            "BuildWatchCheckFolderQueueTraceSummary",
+            @"created:E:\Movies\A\a.mp4",
+            @"renamed-untracked:E:\Movies\B\b.mp4",
+            2
+        );
+
+        Assert.That(
+            result,
+            Is.EqualTo(
+                "compressed=2 first=created path='a.mp4' last=renamed-untracked path='b.mp4'"
+            )
+        );
+    }
+
+    [Test]
+    public void BuildWatchCheckFolderQueueTraceSummary_resume系は値由来として返す()
+    {
+        string result = InvokePrivateStaticString(
+            "BuildWatchCheckFolderQueueTraceSummary",
+            "EverythingPoll",
+            "ui-resume:left-drawer",
+            1
+        );
+
+        Assert.That(
+            result,
+            Is.EqualTo("compressed=1 first=EverythingPoll last=ui-resume value='left-drawer'")
+        );
+    }
+
+    private static string InvokePrivateStaticString(string methodName, params object[] args)
+    {
+        MethodInfo method = typeof(MainWindow).GetMethod(
+            methodName,
+            BindingFlags.Static | BindingFlags.NonPublic
+        )!;
+        Assert.That(method, Is.Not.Null, methodName);
+        return (string)method.Invoke(null, args)!;
+    }
+}

--- a/Tests/IndigoMovieManager.Tests/WatchDeferredUiReloadPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/WatchDeferredUiReloadPolicyTests.cs
@@ -1263,6 +1263,88 @@ public sealed class WatchDeferredUiReloadPolicyTests
         Assert.That(canReuseCurrentOrder, Is.False);
     }
 
+    [TestCase("no-changed-movies")]
+    [TestCase("filter-unavailable")]
+    public void TryBuildChangedMovieRefreshSourceWithReason_局所更新できない理由を返す(
+        string expectedReason
+    )
+    {
+        MovieRecords first = new()
+        {
+            Movie_Path = @"E:\Movies\first.mp4",
+            Movie_Name = "first.mp4",
+        };
+        IEnumerable<MainWindow.WatchChangedMovie> changedMovies =
+            expectedReason == "no-changed-movies"
+                ? []
+                : [
+                    new MainWindow.WatchChangedMovie(
+                        first.Movie_Path,
+                        MainWindow.WatchMovieChangeKind.DisplayedViewRefresh,
+                        MainWindow.WatchMovieDirtyFields.MovieName
+                    ),
+                ];
+        Func<IEnumerable<MovieRecords>, string, IEnumerable<MovieRecords>> filter =
+            expectedReason == "filter-unavailable"
+                ? null
+                : IndigoMovieManager.Infrastructure.SearchService.FilterMovies;
+
+        bool result = MainWindow.TryBuildChangedMovieRefreshSourceWithReason(
+            [first],
+            [first],
+            "",
+            "12",
+            changedMovies,
+            filter,
+            out MovieRecords[] nextFilteredMovies,
+            out bool canReuseCurrentOrder,
+            out string fallbackReason
+        );
+
+        Assert.That(result, Is.False);
+        Assert.That(nextFilteredMovies, Is.Empty);
+        Assert.That(canReuseCurrentOrder, Is.False);
+        Assert.That(fallbackReason, Is.EqualTo(expectedReason));
+    }
+
+    [Test]
+    public void TryBuildChangedMovieRefreshSourceWithReason_dup検索でhash変更ありなら理由を返す()
+    {
+        MovieRecords first = new()
+        {
+            Movie_Path = @"E:\Movies\first.mp4",
+            Movie_Name = "first.mp4",
+            Hash = "same",
+        };
+        MovieRecords second = new()
+        {
+            Movie_Path = @"E:\Movies\second.mp4",
+            Movie_Name = "second.mp4",
+            Hash = "same",
+        };
+
+        bool result = MainWindow.TryBuildChangedMovieRefreshSourceWithReason(
+            [first, second],
+            [second],
+            "{dup}",
+            "12",
+            [
+                new MainWindow.WatchChangedMovie(
+                    @"E:\Movies\second.mp4",
+                    MainWindow.WatchMovieChangeKind.SourceInserted,
+                    MainWindow.WatchMovieDirtyFields.Hash
+                ),
+            ],
+            IndigoMovieManager.Infrastructure.SearchService.FilterMovies,
+            out _,
+            out _,
+            out string fallbackReason
+        );
+
+        Assert.That(result, Is.False);
+        Assert.That(fallbackReason, Is.EqualTo("dup-hash-dirty"));
+    }
+
     [Test]
     public void DoesSearchDependOnDirtyFields_検索列に無関係ならFalseを返す()
     {

--- a/Tests/IndigoMovieManager.Tests/WatchScanCoordinatorPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/WatchScanCoordinatorPolicyTests.cs
@@ -164,6 +164,51 @@ public sealed class WatchScanCoordinatorPolicyTests
     }
 
     [Test]
+    public void ShouldSkipRedundantEverythingPollScanRequest_watch実行中のpollはskipする()
+    {
+        bool result = InvokeShouldSkipRedundantEverythingPollScanRequest(
+            modeName: "Watch",
+            trigger: "EverythingPoll",
+            isRunActive: true,
+            runningModeName: "Watch",
+            hasPendingRequest: false,
+            pendingModeName: "Auto"
+        );
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldSkipRedundantEverythingPollScanRequest_manual保留中のpollはskipする()
+    {
+        bool result = InvokeShouldSkipRedundantEverythingPollScanRequest(
+            modeName: "Watch",
+            trigger: "EverythingPoll",
+            isRunActive: false,
+            runningModeName: "Auto",
+            hasPendingRequest: true,
+            pendingModeName: "Manual"
+        );
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldSkipRedundantEverythingPollScanRequest_autoのみならpollを残す()
+    {
+        bool result = InvokeShouldSkipRedundantEverythingPollScanRequest(
+            modeName: "Watch",
+            trigger: "EverythingPoll",
+            isRunActive: true,
+            runningModeName: "Auto",
+            hasPendingRequest: true,
+            pendingModeName: "Auto"
+        );
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
     public void ResolveExistingMovieMetadataRefreshDisabledMessage_watch_everything_incremental無しなら文言を返す()
     {
         string result = InvokeResolveExistingMovieMetadataRefreshDisabledMessage(
@@ -286,6 +331,32 @@ public sealed class WatchScanCoordinatorPolicyTests
         return (int)method.Invoke(
             null,
             [hasFolderUpdate, enqueuedCount, changedMovieCount]
+        )!;
+    }
+
+    private static bool InvokeShouldSkipRedundantEverythingPollScanRequest(
+        string modeName,
+        string trigger,
+        bool isRunActive,
+        string runningModeName,
+        bool hasPendingRequest,
+        string pendingModeName
+    )
+    {
+        MethodInfo method = typeof(MainWindow).GetMethod(
+            "ShouldSkipRedundantEverythingPollScanRequest",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        Assert.That(method, Is.Not.Null);
+
+        Type modeType = method.GetParameters()[0].ParameterType;
+        object mode = Enum.Parse(modeType, modeName);
+        object runningMode = Enum.Parse(modeType, runningModeName);
+        object pendingMode = Enum.Parse(modeType, pendingModeName);
+
+        return (bool)method.Invoke(
+            null,
+            [mode, trigger, isRunActive, runningMode, hasPendingRequest, pendingMode]
         )!;
     }
 

--- a/Tests/IndigoMovieManager.Tests/WatchUiSuppressionPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/WatchUiSuppressionPolicyTests.cs
@@ -351,6 +351,24 @@ public sealed class WatchUiSuppressionPolicyTests
     }
 
     [Test]
+    public void TryDeferEverythingWatchPollForUserPriority_検索優先中はpollをcatch_upへ逃がす()
+    {
+        MainWindow window = CreateMainWindowForSuppressionTests();
+        SetPrivateField(window, "_watchUiSuppressionSync", new object());
+        SetPrivateField(window, "_userPriorityWorkSync", new object());
+
+        InvokeVoid(window, "BeginUserPriorityWork", "search");
+
+        bool deferred = InvokeBool(window, "TryDeferEverythingWatchPollForUserPriority");
+
+        Assert.That(deferred, Is.True);
+        Assert.That(
+            (bool)GetPrivateField(window, "_watchWorkDeferredWhileSuppressed"),
+            Is.True
+        );
+    }
+
+    [Test]
     public void HandleFolderCheckUiReloadAfterChanges_suppression中は最後のFilterAndSortを走らせずdeferへ戻す()
     {
         MainWindow window = CreateMainWindowForSuppressionTests();

--- a/Tests/IndigoMovieManager.Tests/WatchUiSuppressionPolicyTests.cs
+++ b/Tests/IndigoMovieManager.Tests/WatchUiSuppressionPolicyTests.cs
@@ -298,6 +298,42 @@ public sealed class WatchUiSuppressionPolicyTests
     }
 
     [Test]
+    public void EndWatchUiSuppression_manual_reload中にuser_priority継続ならdeferを保持して終了側resumeへ渡す()
+    {
+        MainWindow window = CreateMainWindowForSuppressionTests();
+        SetPrivateField(window, "_watchUiSuppressionSync", new object());
+        SetPrivateField(window, "_userPriorityWorkSync", new object());
+        SetPrivateField(window, "_checkFolderRequestSync", new object());
+        SetPrivateField(window, "_checkFolderRunLock", new SemaphoreSlim(0, 1));
+
+        List<string> queuedTriggers = [];
+        window.QueueCheckFolderAsyncRequestedForTesting = (mode, trigger) =>
+        {
+            queuedTriggers.Add($"{mode}:{trigger}");
+        };
+
+        InvokeVoid(window, "BeginUserPriorityWork", "search");
+        InvokeVoid(window, "BeginWatchUiSuppression", "manual-reload");
+        InvokeVoid(window, "MarkWatchWorkDeferredWhileSuppressed", "watch-created");
+
+        InvokeVoid(window, "EndWatchUiSuppression", "manual-reload");
+
+        Assert.That(queuedTriggers, Is.Empty);
+        Assert.That(
+            (bool)GetPrivateField(window, "_watchWorkDeferredWhileSuppressed"),
+            Is.True
+        );
+
+        InvokeVoid(window, "EndUserPriorityWork", "search");
+
+        Assert.That(queuedTriggers, Is.EqualTo(["Watch:user-priority-resume:search"]));
+        Assert.That(
+            (bool)GetPrivateField(window, "_watchWorkDeferredWhileSuppressed"),
+            Is.False
+        );
+    }
+
+    [Test]
     public void ManualReloadUiSuppression_手動再読み込み中だけ専用フラグが立つ()
     {
         MainWindow window = CreateMainWindowForSuppressionTests();

--- a/Tests/IndigoMovieManager.Tests/WatcherRegistrationDirectPipelineTests.cs
+++ b/Tests/IndigoMovieManager.Tests/WatcherRegistrationDirectPipelineTests.cs
@@ -901,6 +901,42 @@ public sealed class WatcherRegistrationDirectPipelineTests
         );
     }
 
+    [Test]
+    public async Task ProcessCreatedWatchEventAsync_Shutdown開始後はready後の再走査を積まない()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        string createdMoviePath = Path.Combine(tempRoot, "shutdown-created.mp4");
+        await File.WriteAllBytesAsync(createdMoviePath, [0x1]);
+
+        try
+        {
+            MainWindow window = CreateMainWindow(@"D:\Db\main.wb", currentTabIndex: 2);
+            int queueCheckRequestedCount = 0;
+            window.QueueCheckFolderAsyncRequestedForTesting = (_, _) => queueCheckRequestedCount++;
+
+            MethodInfo beginShutdownMethod = typeof(MainWindow).GetMethod(
+                "BeginWatchEventQueueShutdownForClosing",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            )!;
+            beginShutdownMethod.Invoke(window, null);
+
+            MethodInfo method = GetProcessCreatedWatchEventAsyncMethod();
+            Task task = (Task)method.Invoke(window, [createdMoviePath])!;
+            await task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.That(queueCheckRequestedCount, Is.EqualTo(0));
+            Assert.That(GetPrivateField<bool>(window, "_hasPendingCheckFolderRequest"), Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     private static MainWindow CreateMainWindow(string dbFullPath, int currentTabIndex)
     {
         MainWindow window = (MainWindow)RuntimeHelpers.GetUninitializedObject(typeof(MainWindow));
@@ -943,6 +979,16 @@ public sealed class WatcherRegistrationDirectPipelineTests
             binder: null,
             types: [requestType, typeof(string)],
             modifiers: null
+        )!;
+        Assert.That(method, Is.Not.Null);
+        return method;
+    }
+
+    private static MethodInfo GetProcessCreatedWatchEventAsyncMethod()
+    {
+        MethodInfo method = typeof(MainWindow).GetMethod(
+            "ProcessCreatedWatchEventAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic
         )!;
         Assert.That(method, Is.Not.Null);
         return method;

--- a/Thumbnail/MainWindow.ThumbnailQueue.cs
+++ b/Thumbnail/MainWindow.ThumbnailQueue.cs
@@ -53,6 +53,8 @@ namespace IndigoMovieManager
         // DBリース所有者。アプリ起動中は固定し、UpdateStatusの所有者一致判定に使う。
         private readonly string thumbnailQueueOwnerInstanceId =
             $"{Environment.MachineName}:{Environment.ProcessId}:{Guid.NewGuid():N}";
+        // サムネ総数の背景走査がDB切替後に戻ってきても、古い結果を捨てるための印。
+        private long thumbnailProgressInitialCountScanStamp;
 
         // サムネイルジョブのユニークキーを生成する。
 
@@ -538,16 +540,83 @@ namespace IndigoMovieManager
                 return;
             }
 
-            _thumbnailProgressRuntime.Reset(ResolveThumbnailProgressInitialCreatedCount());
+            _thumbnailProgressRuntime.Reset();
             ThumbnailPreviewCache.Shared.Clear();
             ThumbnailPreviewLatencyTracker.Reset();
             RequestThumbnailProgressSnapshotRefresh();
+            QueueThumbnailProgressInitialCreatedCountRefresh();
+        }
+
+        // 総作成数の全走査はUI導線から外し、DB/フォルダが同じ時だけ後追い反映する。
+        private void QueueThumbnailProgressInitialCreatedCountRefresh()
+        {
+            string dbFullPath = MainVM?.DbInfo?.DBFullPath ?? "";
+            string thumbFolder = MainVM?.DbInfo?.ThumbFolder ?? "";
+            long scanStamp = Interlocked.Increment(ref thumbnailProgressInitialCountScanStamp);
+            if (string.IsNullOrWhiteSpace(thumbFolder))
+            {
+                return;
+            }
+
+            _ = Task.Run(() => ResolveThumbnailProgressInitialCreatedCount(thumbFolder))
+                .ContinueWith(
+                    task =>
+                    {
+                        if (task.IsFaulted)
+                        {
+                            DebugRuntimeLog.Write(
+                                "thumbnail-progress",
+                                $"initial created count scan task failed: folder='{thumbFolder}' err='{task.Exception?.GetBaseException().Message}'"
+                            );
+                            return;
+                        }
+
+                        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+                        {
+                            return;
+                        }
+
+                        _ = Dispatcher.BeginInvoke(
+                            new Action(
+                                () =>
+                                {
+                                    if (
+                                        scanStamp != thumbnailProgressInitialCountScanStamp
+                                        || !AreSameMainDbPath(
+                                            dbFullPath,
+                                            MainVM?.DbInfo?.DBFullPath ?? ""
+                                        )
+                                        || !string.Equals(
+                                            thumbFolder,
+                                            MainVM?.DbInfo?.ThumbFolder ?? "",
+                                            StringComparison.OrdinalIgnoreCase
+                                        )
+                                    )
+                                    {
+                                        return;
+                                    }
+
+                                    _thumbnailProgressRuntime.ApplyInitialTotalCreatedCount(
+                                        task.Result
+                                    );
+                                    RequestThumbnailProgressSnapshotRefresh();
+                                }
+                            ),
+                            DispatcherPriority.Background
+                        );
+                    },
+                    TaskScheduler.Default
+                );
         }
 
         // 総作成の初期値は、現在DBのサムネイルフォルダに実在するファイル数をそのまま使う。
         private long ResolveThumbnailProgressInitialCreatedCount()
         {
-            string thumbFolder = MainVM?.DbInfo?.ThumbFolder ?? "";
+            return ResolveThumbnailProgressInitialCreatedCount(MainVM?.DbInfo?.ThumbFolder ?? "");
+        }
+
+        private static long ResolveThumbnailProgressInitialCreatedCount(string thumbFolder)
+        {
             if (string.IsNullOrWhiteSpace(thumbFolder) || !Directory.Exists(thumbFolder))
             {
                 return 0;

--- a/Thumbnail/MainWindow.ThumbnailUserActionContext.cs
+++ b/Thumbnail/MainWindow.ThumbnailUserActionContext.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
+using System.Windows.Threading;
 using IndigoMovieManager.Thumbnail;
 
 namespace IndigoMovieManager
@@ -220,13 +221,7 @@ namespace IndigoMovieManager
                     );
                 }
 
-                if (Dispatcher.CheckAccess())
-                {
-                    showPopup();
-                    return;
-                }
-
-                Dispatcher.Invoke(showPopup);
+                PostThumbnailUserActionUiNotification(showPopup);
                 return;
             }
 
@@ -244,13 +239,24 @@ namespace IndigoMovieManager
                 );
             }
 
-            if (Dispatcher.CheckAccess())
+            PostThumbnailUserActionUiNotification(showOverlay);
+        }
+
+        // 結果通知は待機不要なので、背景側をUIスレッド完了待ちで止めない。
+        private void PostThumbnailUserActionUiNotification(Action action)
+        {
+            if (action == null || Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
             {
-                showOverlay();
                 return;
             }
 
-            Dispatcher.Invoke(showOverlay);
+            if (Dispatcher.CheckAccess())
+            {
+                action();
+                return;
+            }
+
+            _ = Dispatcher.BeginInvoke(action, DispatcherPriority.Background);
         }
 
         // OK だけの結果通知は modal にせず、長め表示の overlay msg へ寄せる。

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -260,78 +260,86 @@ namespace IndigoMovieManager
                 return;
             }
 
-            EnsureManualPlayerResizeTrackingHooked();
-            UpdatePlayerTabLayoutMode();
-
-            if (!ReferenceEquals(Tabs?.SelectedItem, TabPlayer))
+            BeginUserPriorityWork("player");
+            try
             {
-                _suppressPlayerTabActivationAutoOpen = true;
-                try
+                EnsureManualPlayerResizeTrackingHooked();
+                UpdatePlayerTabLayoutMode();
+
+                if (!ReferenceEquals(Tabs?.SelectedItem, TabPlayer))
+                {
+                    _suppressPlayerTabActivationAutoOpen = true;
+                    try
+                    {
+                        if (syncPlayerSelection)
+                        {
+                            SyncUpperTabPlayerSelection(movie);
+                        }
+
+                        SelectUpperTabByFixedIndex(PlayerTabIndex);
+                        await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+                    }
+                    finally
+                    {
+                        _suppressPlayerTabActivationAutoOpen = false;
+                    }
+                }
+                else
                 {
                     if (syncPlayerSelection)
                     {
                         SyncUpperTabPlayerSelection(movie);
                     }
+                }
 
-                    SelectUpperTabByFixedIndex(PlayerTabIndex);
-                    await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
-                }
-                finally
+                // プレイヤータブの通常再生は WebView2 を正面採用し、
+                // 手動サムネ位置合わせだけ従来の MediaElement を残す。
+                if (ShouldUseWebViewPlayerForPlayerTab(movie.Movie_Path, focusTimeSlider))
                 {
-                    _suppressPlayerTabActivationAutoOpen = false;
+                    await OpenMovieInWebViewPlayerAsync(
+                        movie,
+                        startMilliseconds,
+                        playImmediately,
+                        mute
+                    );
+                    return;
                 }
-            }
-            else
-            {
-                if (syncPlayerSelection)
-                {
-                    SyncUpperTabPlayerSelection(movie);
-                }
-            }
 
-            // プレイヤータブの通常再生は WebView2 を正面採用し、
-            // 手動サムネ位置合わせだけ従来の MediaElement を残す。
-            if (ShouldUseWebViewPlayerForPlayerTab(movie.Movie_Path, focusTimeSlider))
-            {
-                await OpenMovieInWebViewPlayerAsync(
-                    movie,
+                if (_isWebViewPlayerActive)
+                {
+                    ResetWebViewPlayerSurface();
+                }
+
+                ShowPlayerSurface();
+                StopDispatcherTimerSafely(timer, nameof(timer));
+                RememberPendingPlayerPlaybackRequest(
                     startMilliseconds,
                     playImmediately,
-                    mute
+                    mute,
+                    focusTimeSlider
                 );
-                return;
-            }
 
-            if (_isWebViewPlayerActive)
+                bool sourceChanged =
+                    !string.Equals(
+                        _currentPlayerMoviePath,
+                        movie.Movie_Path,
+                        System.StringComparison.OrdinalIgnoreCase
+                    )
+                    || uxVideoPlayer.Source == null;
+                if (sourceChanged)
+                {
+                    uxVideoPlayer.Stop();
+                    uxVideoPlayer.Source = new System.Uri(movie.Movie_Path);
+                    _currentPlayerMoviePath = movie.Movie_Path;
+                    return;
+                }
+
+                await ApplyPendingPlayerPlaybackRequestAsync();
+            }
+            finally
             {
-                ResetWebViewPlayerSurface();
+                EndUserPriorityWork("player");
             }
-
-            ShowPlayerSurface();
-            StopDispatcherTimerSafely(timer, nameof(timer));
-            RememberPendingPlayerPlaybackRequest(
-                startMilliseconds,
-                playImmediately,
-                mute,
-                focusTimeSlider
-            );
-
-            bool sourceChanged =
-                !string.Equals(
-                    _currentPlayerMoviePath,
-                    movie.Movie_Path,
-                    System.StringComparison.OrdinalIgnoreCase
-                )
-                || uxVideoPlayer.Source == null;
-            if (sourceChanged)
-            {
-                uxVideoPlayer.Stop();
-                uxVideoPlayer.Source = new System.Uri(movie.Movie_Path);
-                _currentPlayerMoviePath = movie.Movie_Path;
-                return;
-            }
-
-            await ApplyPendingPlayerPlaybackRequestAsync();
         }
 
         // MediaElement が苦手な形式だけ、Chromium の HTML5 video へ切り替えて再生互換を確保する。

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -37,6 +37,7 @@ namespace IndigoMovieManager
         private bool _pendingWebViewMute;
         private bool _isWebViewPlayerActive;
         private bool _isWebViewPlayerBridgeRegistered;
+        private bool _isPlayerUserPriorityReleasePending;
         private bool _isHandlingWebViewNativeFullscreenRequest;
         private bool _isSyncingDetachedWindowDomFullscreen;
         private Task<CoreWebView2Environment> _playerWebViewEnvironmentTask;
@@ -260,7 +261,9 @@ namespace IndigoMovieManager
                 return;
             }
 
+            ReleasePendingPlayerUserPriorityWork();
             BeginUserPriorityWork("player");
+            bool releaseUserPriorityOnExit = true;
             try
             {
                 EnsureManualPlayerResizeTrackingHooked();
@@ -296,7 +299,7 @@ namespace IndigoMovieManager
                 // 手動サムネ位置合わせだけ従来の MediaElement を残す。
                 if (ShouldUseWebViewPlayerForPlayerTab(movie.Movie_Path, focusTimeSlider))
                 {
-                    await OpenMovieInWebViewPlayerAsync(
+                    releaseUserPriorityOnExit = !await OpenMovieInWebViewPlayerAsync(
                         movie,
                         startMilliseconds,
                         playImmediately,
@@ -331,6 +334,8 @@ namespace IndigoMovieManager
                     uxVideoPlayer.Stop();
                     uxVideoPlayer.Source = new System.Uri(movie.Movie_Path);
                     _currentPlayerMoviePath = movie.Movie_Path;
+                    MarkPlayerUserPriorityReleasePending();
+                    releaseUserPriorityOnExit = false;
                     return;
                 }
 
@@ -338,12 +343,15 @@ namespace IndigoMovieManager
             }
             finally
             {
-                EndUserPriorityWork("player");
+                if (releaseUserPriorityOnExit)
+                {
+                    EndUserPriorityWork("player");
+                }
             }
         }
 
         // MediaElement が苦手な形式だけ、Chromium の HTML5 video へ切り替えて再生互換を確保する。
-        private async Task OpenMovieInWebViewPlayerAsync(
+        private async Task<bool> OpenMovieInWebViewPlayerAsync(
             MovieRecords movie,
             int startMilliseconds,
             bool playImmediately,
@@ -352,12 +360,12 @@ namespace IndigoMovieManager
         {
             if (movie == null || string.IsNullOrWhiteSpace(movie.Movie_Path) || uxWebVideoPlayer == null)
             {
-                return;
+                return false;
             }
 
             if (!await EnsureWebVideoPlayerReadyAsync())
             {
-                return;
+                return false;
             }
 
             _isWebViewPlayerActive = true;
@@ -390,10 +398,28 @@ namespace IndigoMovieManager
             {
                 uxWebVideoPlayer.Source = new System.Uri(movie.Movie_Path);
                 _currentWebViewPlayerPath = movie.Movie_Path;
-                return;
+                MarkPlayerUserPriorityReleasePending();
+                return true;
             }
 
             await ApplyPendingWebViewPlaybackRequestAsync();
+            return false;
+        }
+
+        private void MarkPlayerUserPriorityReleasePending()
+        {
+            _isPlayerUserPriorityReleasePending = true;
+        }
+
+        private void ReleasePendingPlayerUserPriorityWork()
+        {
+            if (!_isPlayerUserPriorityReleasePending)
+            {
+                return;
+            }
+
+            _isPlayerUserPriorityReleasePending = false;
+            EndUserPriorityWork("player");
         }
 
         // Source 差し替えと MediaOpened の間でも、再生要求を落とさず持ち運ぶ。
@@ -413,71 +439,90 @@ namespace IndigoMovieManager
 
         private async Task ApplyPendingPlayerPlaybackRequestAsync()
         {
+            bool shouldReleaseUserPriority =
+                _hasPendingPlayerPlaybackRequest || _isPlayerUserPriorityReleasePending;
             if (!_hasPendingPlayerPlaybackRequest || uxVideoPlayer == null)
             {
+                if (shouldReleaseUserPriority)
+                {
+                    ReleasePendingPlayerUserPriorityWork();
+                }
                 return;
             }
 
-            int startMilliseconds = _pendingPlayerStartMilliseconds;
-            bool playImmediately = _pendingPlayerPlayImmediately;
-            bool mute = _pendingPlayerMute;
-            bool focusTimeSlider = _pendingPlayerFocusTimeSlider;
-            _hasPendingPlayerPlaybackRequest = false;
-
-            double restoreVolume = uxVolumeSlider?.Value ?? 0.5d;
-            uxVideoPlayer.Volume = mute ? 0d : restoreVolume;
-
-            if (startMilliseconds > 0)
+            try
             {
-                uxVideoPlayer.Position = System.TimeSpan.FromMilliseconds(startMilliseconds);
-            }
+                int startMilliseconds = _pendingPlayerStartMilliseconds;
+                bool playImmediately = _pendingPlayerPlayImmediately;
+                bool mute = _pendingPlayerMute;
+                bool focusTimeSlider = _pendingPlayerFocusTimeSlider;
+                _hasPendingPlayerPlaybackRequest = false;
 
-            uxVideoPlayer.Play();
-            UpdateManualPlayerViewport();
-            UpdatePlayerPositionUi(uxVideoPlayer.Position);
+                double restoreVolume = uxVolumeSlider?.Value ?? 0.5d;
+                uxVideoPlayer.Volume = mute ? 0d : restoreVolume;
 
-            if (playImmediately)
-            {
-                IsPlaying = true;
-                TryStartDispatcherTimer(timer, nameof(timer));
-            }
-            else
-            {
-                await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
-                uxVideoPlayer.Pause();
-                IsPlaying = false;
-                StopDispatcherTimerSafely(timer, nameof(timer));
-
-                if (!mute)
+                if (startMilliseconds > 0)
                 {
-                    uxVideoPlayer.Volume = restoreVolume;
+                    uxVideoPlayer.Position = System.TimeSpan.FromMilliseconds(startMilliseconds);
+                }
+
+                uxVideoPlayer.Play();
+                UpdateManualPlayerViewport();
+                UpdatePlayerPositionUi(uxVideoPlayer.Position);
+
+                if (playImmediately)
+                {
+                    IsPlaying = true;
+                    TryStartDispatcherTimer(timer, nameof(timer));
+                }
+                else
+                {
+                    await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+                    uxVideoPlayer.Pause();
+                    IsPlaying = false;
+                    StopDispatcherTimerSafely(timer, nameof(timer));
+
+                    if (!mute)
+                    {
+                        uxVideoPlayer.Volume = restoreVolume;
+                    }
+                }
+
+                if (focusTimeSlider)
+                {
+                    uxTimeSlider.Focus();
                 }
             }
-
-            if (focusTimeSlider)
+            finally
             {
-                uxTimeSlider.Focus();
+                if (shouldReleaseUserPriority)
+                {
+                    ReleasePendingPlayerUserPriorityWork();
+                }
             }
         }
 
         private void ShowPlayerSurface()
         {
-            PlayerArea.Visibility = Visibility.Visible;
-            PlayerController.Visibility = _isWebViewPlayerActive
-                ? Visibility.Collapsed
-                : Visibility.Visible;
-            uxVideoPlayer.Visibility = _isWebViewPlayerActive
-                ? Visibility.Collapsed
-                : Visibility.Visible;
+            SetPlayerVisibilityIfChanged(PlayerArea, Visibility.Visible);
+            SetPlayerVisibilityIfChanged(
+                PlayerController,
+                _isWebViewPlayerActive ? Visibility.Collapsed : Visibility.Visible
+            );
+            SetPlayerVisibilityIfChanged(
+                uxVideoPlayer,
+                _isWebViewPlayerActive ? Visibility.Collapsed : Visibility.Visible
+            );
             if (uxWebVideoPlayer != null)
             {
-                uxWebVideoPlayer.Visibility = _isWebViewPlayerActive
-                    ? Visibility.Visible
-                    : Visibility.Collapsed;
+                SetPlayerVisibilityIfChanged(
+                    uxWebVideoPlayer,
+                    _isWebViewPlayerActive ? Visibility.Visible : Visibility.Collapsed
+                );
             }
             if (PlayerEmptyState != null)
             {
-                PlayerEmptyState.Visibility = Visibility.Collapsed;
+                SetPlayerVisibilityIfChanged(PlayerEmptyState, Visibility.Collapsed);
             }
         }
 
@@ -485,8 +530,19 @@ namespace IndigoMovieManager
         {
             if (PlayerEmptyState != null)
             {
-                PlayerEmptyState.Visibility = Visibility.Visible;
+                SetPlayerVisibilityIfChanged(PlayerEmptyState, Visibility.Visible);
             }
+        }
+
+        private static void SetPlayerVisibilityIfChanged(UIElement element, Visibility visibility)
+        {
+            if (element == null || element.Visibility == visibility)
+            {
+                return;
+            }
+
+            // 同じ表示状態の再代入を避け、Player 操作後の余計なレイアウト更新を増やさない。
+            element.Visibility = visibility;
         }
 
         // WebView2 は別 HWND として前面に出るため、左ドロワー操作中だけ描画面を退避する。
@@ -508,7 +564,11 @@ namespace IndigoMovieManager
                 return;
             }
 
-            if (TabPlayer?.IsSelected == true && !_isDetachedPlayerFullscreenActive)
+            if (
+                TabPlayer?.IsSelected == true
+                && !_isDetachedPlayerFullscreenActive
+                && uxWebVideoPlayer.Visibility != Visibility.Visible
+            )
             {
                 uxWebVideoPlayer.Visibility = Visibility.Visible;
                 DebugRuntimeLog.Write("ui-tempo", "player webview restored after left drawer");
@@ -677,6 +737,11 @@ namespace IndigoMovieManager
             {
                 foreach (ListView list in GetAllUpperTabPlayerLists())
                 {
+                    if (ReferenceEquals(list.SelectedItem, selectedMovie))
+                    {
+                        continue;
+                    }
+
                     list.SelectedItem = selectedMovie;
                 }
 
@@ -710,7 +775,10 @@ namespace IndigoMovieManager
                         continue;
                     }
 
-                    list.SelectedItem = selectedMovie;
+                    if (!ReferenceEquals(list.SelectedItem, selectedMovie))
+                    {
+                        list.SelectedItem = selectedMovie;
+                    }
                 }
             }
             finally
@@ -739,63 +807,79 @@ namespace IndigoMovieManager
 
         private async Task ApplyPendingWebViewPlaybackRequestAsync()
         {
+            bool shouldReleaseUserPriority =
+                _hasPendingWebViewPlaybackRequest || _isPlayerUserPriorityReleasePending;
             if (
                 !_hasPendingWebViewPlaybackRequest
                 || !_isWebViewPlayerActive
                 || uxWebVideoPlayer?.CoreWebView2 == null
             )
             {
+                if (shouldReleaseUserPriority)
+                {
+                    ReleasePendingPlayerUserPriorityWork();
+                }
                 return;
             }
 
-            int startMilliseconds = _pendingWebViewStartMilliseconds;
-            bool playImmediately = _pendingWebViewPlayImmediately;
-            bool mute = _pendingWebViewMute;
-            _hasPendingWebViewPlaybackRequest = false;
+            try
+            {
+                int startMilliseconds = _pendingWebViewStartMilliseconds;
+                bool playImmediately = _pendingWebViewPlayImmediately;
+                bool mute = _pendingWebViewMute;
+                _hasPendingWebViewPlaybackRequest = false;
 
-            string seconds = (startMilliseconds / 1000d).ToString(
-                System.Globalization.CultureInfo.InvariantCulture
-            );
-            string volume = uxVolumeSlider.Value.ToString(
-                System.Globalization.CultureInfo.InvariantCulture
-            );
-            string script = $$"""
-                (() => {
-                  const player = document.querySelector('video');
-                  if (!player) {
-                    return;
-                  }
+                string seconds = (startMilliseconds / 1000d).ToString(
+                    System.Globalization.CultureInfo.InvariantCulture
+                );
+                string volume = uxVolumeSlider.Value.ToString(
+                    System.Globalization.CultureInfo.InvariantCulture
+                );
+                string script = $$"""
+                    (() => {
+                      const player = document.querySelector('video');
+                      if (!player) {
+                        return;
+                      }
 
-                  const applyPlayback = () => {
-                    try {
-                      player.currentTime = {{seconds}};
-                    } catch {}
+                      const applyPlayback = () => {
+                        try {
+                          player.currentTime = {{seconds}};
+                        } catch {}
 
-                    player.muted = {{(mute ? "true" : "false")}};
-                    player.volume = {{volume}};
-                    player.dataset.indigoPlayerHostVolumeApplied = '1';
+                        player.muted = {{(mute ? "true" : "false")}};
+                        player.volume = {{volume}};
+                        player.dataset.indigoPlayerHostVolumeApplied = '1';
 
-                    const playPromise = player.play();
-                    if (playPromise) {
-                      playPromise.catch(() => {});
-                    }
+                        const playPromise = player.play();
+                        if (playPromise) {
+                          playPromise.catch(() => {});
+                        }
 
-                    if (!{{(playImmediately ? "true" : "false")}}) {
-                      Promise.resolve(playPromise).finally(() => player.pause());
-                    }
-                  };
+                        if (!{{(playImmediately ? "true" : "false")}}) {
+                          Promise.resolve(playPromise).finally(() => player.pause());
+                        }
+                      };
 
-                  if (player.readyState >= 1) {
-                    applyPlayback();
-                    return;
-                  }
+                      if (player.readyState >= 1) {
+                        applyPlayback();
+                        return;
+                      }
 
-                  player.addEventListener('loadedmetadata', applyPlayback, { once: true });
-                })();
-                """;
-            await uxWebVideoPlayer.ExecuteScriptAsync(script);
-            IsPlaying = playImmediately;
-            UpdatePlayerPositionUi(System.TimeSpan.FromMilliseconds(startMilliseconds));
+                      player.addEventListener('loadedmetadata', applyPlayback, { once: true });
+                    })();
+                    """;
+                await uxWebVideoPlayer.ExecuteScriptAsync(script);
+                IsPlaying = playImmediately;
+                UpdatePlayerPositionUi(System.TimeSpan.FromMilliseconds(startMilliseconds));
+            }
+            finally
+            {
+                if (shouldReleaseUserPriority)
+                {
+                    ReleasePendingPlayerUserPriorityWork();
+                }
+            }
         }
 
         private async void UxWebVideoPlayer_NavigationCompleted(

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -42,6 +42,7 @@ namespace IndigoMovieManager
         private bool _isSyncingDetachedWindowDomFullscreen;
         private Task<CoreWebView2Environment> _playerWebViewEnvironmentTask;
         private DispatcherOperation _playerBackgroundYieldOperation;
+        private ulong _pendingWebViewNavigationId;
         private string _currentPlayerMoviePath = "";
         private string _currentWebViewPlayerPath = "";
 
@@ -931,14 +932,36 @@ namespace IndigoMovieManager
             }
         }
 
+        private void UxWebVideoPlayer_NavigationStarting(
+            object sender,
+            CoreWebView2NavigationStartingEventArgs e
+        )
+        {
+            if (_isWebViewPlayerActive)
+            {
+                _pendingWebViewNavigationId = e.NavigationId;
+            }
+        }
+
         private async void UxWebVideoPlayer_NavigationCompleted(
             object sender,
             CoreWebView2NavigationCompletedEventArgs e
         )
         {
-            if (!e.IsSuccess || !_isWebViewPlayerActive)
+            if (!_isWebViewPlayerActive)
+            {
+                return;
+            }
+
+            if (e.NavigationId != _pendingWebViewNavigationId)
+            {
+                return;
+            }
+
+            if (!e.IsSuccess)
             {
                 _hasPendingWebViewPlaybackRequest = false;
+                IsPlaying = false;
                 ReleasePendingPlayerUserPriorityWork();
                 return;
             }

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -101,19 +101,32 @@ namespace IndigoMovieManager
             return items;
         }
 
-        private void SelectUpperTabPlayerMovieRecord(MovieRecords record)
+        private bool SelectUpperTabPlayerMovieRecord(MovieRecords record)
         {
             if (record == null)
             {
-                return;
+                return false;
             }
 
+            bool selectionChanged = false;
             foreach (ListView list in GetAllUpperTabPlayerLists())
             {
+                if (ReferenceEquals(list.SelectedItem, record))
+                {
+                    continue;
+                }
+
                 list.SelectedItem = record;
+                selectionChanged = true;
             }
 
-            GetUpperTabPlayerList()?.ScrollIntoView(record);
+            if (selectionChanged)
+            {
+                // 同じ選択の再同期ではスクロールと可視範囲更新を積み直さない。
+                GetUpperTabPlayerList()?.ScrollIntoView(record);
+            }
+
+            return selectionChanged;
         }
 
         // プレイヤータブへ飛ばす時だけ、選択イベントの自動再生を一時停止して狙った動画へ揃える。
@@ -125,16 +138,20 @@ namespace IndigoMovieManager
             }
 
             _suppressPlayerThumbnailSelectionChanged = true;
+            bool selectionChanged = false;
             try
             {
-                SelectUpperTabPlayerMovieRecord(record);
+                selectionChanged = SelectUpperTabPlayerMovieRecord(record);
             }
             finally
             {
                 _suppressPlayerThumbnailSelectionChanged = false;
             }
 
-            RequestUpperTabVisibleRangeRefresh(immediate: true, reason: "player-view-mode");
+            if (selectionChanged)
+            {
+                RequestUpperTabVisibleRangeRefresh(immediate: true, reason: "player-view-mode");
+            }
         }
 
         // プレイヤータブ選択時は先頭選択を揃えたうえで、左ペインへ再生内容を同期する。

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -897,9 +897,13 @@ namespace IndigoMovieManager
                           player.currentTime = {{seconds}};
                         } catch {}
 
+                        player.dataset.indigoPlayerHostVolumeApplying = '1';
                         player.muted = {{(mute ? "true" : "false")}};
                         player.volume = {{volume}};
                         player.dataset.indigoPlayerHostVolumeApplied = '1';
+                        setTimeout(() => {
+                          delete player.dataset.indigoPlayerHostVolumeApplying;
+                        }, 0);
 
                         const playPromise = player.play();
                         if (playPromise) {
@@ -1255,6 +1259,10 @@ namespace IndigoMovieManager
                     player.controls = true;
 
                     const notifyVolume = () => {
+                      if (player.dataset.indigoPlayerHostVolumeApplying === '1') {
+                        return;
+                      }
+
                       if (player.dataset.indigoPlayerHostVolumeApplied !== '1') {
                         return;
                       }

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -41,6 +41,7 @@ namespace IndigoMovieManager
         private bool _isHandlingWebViewNativeFullscreenRequest;
         private bool _isSyncingDetachedWindowDomFullscreen;
         private Task<CoreWebView2Environment> _playerWebViewEnvironmentTask;
+        private DispatcherOperation _playerBackgroundYieldOperation;
         private string _currentPlayerMoviePath = "";
         private string _currentWebViewPlayerPath = "";
 
@@ -110,6 +111,8 @@ namespace IndigoMovieManager
             }
 
             bool selectionChanged = false;
+            bool activeListSelectionChanged = false;
+            ListView activeList = GetUpperTabPlayerList();
             foreach (ListView list in GetAllUpperTabPlayerLists())
             {
                 if (ReferenceEquals(list.SelectedItem, record))
@@ -119,11 +122,15 @@ namespace IndigoMovieManager
 
                 list.SelectedItem = record;
                 selectionChanged = true;
+                if (ReferenceEquals(list, activeList))
+                {
+                    activeListSelectionChanged = true;
+                }
             }
 
-            if (selectionChanged)
+            if (activeListSelectionChanged)
             {
-                // 同じ選択の再同期ではスクロールと可視範囲更新を積み直さない。
+                // 表示中リストの選択が変わった時だけ再スクロールし、裏側List同期だけでは積み直さない。
                 GetUpperTabPlayerList()?.ScrollIntoView(record);
             }
 
@@ -280,7 +287,7 @@ namespace IndigoMovieManager
                         }
 
                         SelectUpperTabByFixedIndex(PlayerTabIndex);
-                        await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+                        await WaitForPlayerDispatcherBackgroundAsync();
                     }
                     finally
                     {
@@ -422,6 +429,39 @@ namespace IndigoMovieManager
             EndUserPriorityWork("player");
         }
 
+        // 同一タイミングの no-op Dispatcher 待機は1本へ畳み、選択連打時の積み過ぎを抑える。
+        private async Task WaitForPlayerDispatcherBackgroundAsync()
+        {
+            if (Dispatcher == null || Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+            {
+                return;
+            }
+
+            DispatcherOperation pendingOperation = _playerBackgroundYieldOperation;
+            if (
+                pendingOperation == null
+                || pendingOperation.Status == DispatcherOperationStatus.Completed
+                || pendingOperation.Status == DispatcherOperationStatus.Aborted
+            )
+            {
+                pendingOperation = Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+                _playerBackgroundYieldOperation = pendingOperation;
+            }
+
+            try
+            {
+                await pendingOperation.Task;
+            }
+            catch (InvalidOperationException)
+            {
+                // shutdown 競合時はここで止めず、次の操作へ進める。
+            }
+            catch (TaskCanceledException)
+            {
+                // Dispatcher 側で中断された待機は安全に捨てる。
+            }
+        }
+
         // Source 差し替えと MediaOpened の間でも、再生要求を落とさず持ち運ぶ。
         private void RememberPendingPlayerPlaybackRequest(
             int startMilliseconds,
@@ -477,7 +517,7 @@ namespace IndigoMovieManager
                 }
                 else
                 {
-                    await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+                    await WaitForPlayerDispatcherBackgroundAsync();
                     uxVideoPlayer.Pause();
                     IsPlaying = false;
                     StopDispatcherTimerSafely(timer, nameof(timer));
@@ -735,6 +775,8 @@ namespace IndigoMovieManager
             _suppressPlayerThumbnailSelectionChanged = true;
             try
             {
+                bool activeListSelectionChanged = false;
+                ListView activeList = GetUpperTabPlayerList();
                 foreach (ListView list in GetAllUpperTabPlayerLists())
                 {
                     if (ReferenceEquals(list.SelectedItem, selectedMovie))
@@ -743,9 +785,16 @@ namespace IndigoMovieManager
                     }
 
                     list.SelectedItem = selectedMovie;
+                    if (ReferenceEquals(list, activeList))
+                    {
+                        activeListSelectionChanged = true;
+                    }
                 }
 
-                GetUpperTabPlayerList()?.ScrollIntoView(selectedMovie);
+                if (activeListSelectionChanged)
+                {
+                    GetUpperTabPlayerList()?.ScrollIntoView(selectedMovie);
+                }
             }
             finally
             {
@@ -889,6 +938,8 @@ namespace IndigoMovieManager
         {
             if (!e.IsSuccess || !_isWebViewPlayerActive)
             {
+                _hasPendingWebViewPlaybackRequest = false;
+                ReleasePendingPlayerUserPriorityWork();
                 return;
             }
 
@@ -983,7 +1034,7 @@ namespace IndigoMovieManager
                     })();
                     """
                 );
-                await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+                await WaitForPlayerDispatcherBackgroundAsync();
                 await OpenMainWindowPlayerFullscreenAsync();
             }
             catch (Exception ex)

--- a/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
+++ b/UpperTabs/Player/MainWindow.UpperTabs.PlayerTab.cs
@@ -1323,6 +1323,9 @@ namespace IndigoMovieManager
             _hasPendingWebViewPlaybackRequest = false;
             _isWebViewPlayerActive = false;
             _currentWebViewPlayerPath = "";
+            _pendingWebViewNavigationId = 0;
+            // WebView停止・切替では NavigationCompleted が後着するため、ここでユーザー優先区間を畳む。
+            ReleasePendingPlayerUserPriorityWork();
 
             if (uxWebVideoPlayer == null)
             {

--- a/UserControls/Bookmark.xaml.cs
+++ b/UserControls/Bookmark.xaml.cs
@@ -32,15 +32,21 @@ namespace IndigoMovieManager.UserControls
             }
         }
 
-        private void FileNameLink_Click(object sender, RoutedEventArgs e)
+        private async void FileNameLink_Click(object sender, RoutedEventArgs e)
         {
-            // ブックマーク名クリック時はSearchBoxへ名前をセットする。
+            // ブックマーク名クリック時も検索正本へ合流させ、
+            // SearchBox直代入由来の余計なイベント連鎖を減らす。
             MainWindow ownerWindow = (MainWindow)Window.GetWindow(this);
             var item = (Hyperlink)sender;
             if (item != null)
             {
                 MovieRecords mv = item.DataContext as MovieRecords;
-                ownerWindow.SearchBox.Text = mv.Movie_Body;
+                if (mv == null)
+                {
+                    return;
+                }
+
+                await ownerWindow.ApplySearchKeywordFromLinkAsync(mv.Movie_Body ?? "");
             }
         }
 

--- a/UserControls/ExtDetail.xaml.cs
+++ b/UserControls/ExtDetail.xaml.cs
@@ -442,7 +442,7 @@ namespace IndigoMovieManager.UserControls
             }
         }
 
-        private void FileNameLink_Click(object sender, RoutedEventArgs e)
+        private async void FileNameLink_Click(object sender, RoutedEventArgs e)
         {
             // ファイル名リンクは完全一致検索（"..."）としてSearchBoxへ投入する。
             // DataContext からファイル名を取得
@@ -457,20 +457,11 @@ namespace IndigoMovieManager.UserControls
                 return;
             }
 
-            // ダブルクォーテーションで括ってSearchBoxとViewModelにセット
             var quoted = $"\"{record.Movie_Body}\"";
-            ownerWindow.SearchBox.Text = quoted;
-            ownerWindow.MainVM.DbInfo.SearchKeyword = quoted;
-
-            // 検索処理を実行
-            ownerWindow.FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);
-            ownerWindow.SelectFirstItem();
-
-            // SearchBoxにフォーカスを当てる
-            ownerWindow.SearchBox.Focus();
+            await ownerWindow.ApplySearchKeywordFromLinkAsync(quoted);
         }
 
-        private void Ext_Click(object sender, RoutedEventArgs e)
+        private async void Ext_Click(object sender, RoutedEventArgs e)
         {
             // 拡張子リンクは拡張子検索としてSearchBoxへ投入する。
             MainWindow ownerWindow = Window.GetWindow(this) as MainWindow;
@@ -491,16 +482,7 @@ namespace IndigoMovieManager.UserControls
                 return;
             }
 
-            // 検索キーワードもViewModelに反映
-            ownerWindow.SearchBox.Text = mv.Ext;
-            ownerWindow.MainVM.DbInfo.SearchKeyword = mv.Ext;
-
-            // 検索処理を実行
-            ownerWindow.FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);
-            ownerWindow.SelectFirstItem();
-
-            // SearchBoxにフォーカスを当てる
-            ownerWindow.SearchBox.Focus();
+            await ownerWindow.ApplySearchKeywordFromLinkAsync(mv.Ext);
         }
 
         private static int ResolveDetailThumbnailDecodePixelHeight(string mode)

--- a/UserControls/TagControl.xaml.cs
+++ b/UserControls/TagControl.xaml.cs
@@ -24,7 +24,7 @@ namespace IndigoMovieManager.UserControls
             InitializeComponent();
         }
 
-        private void Hyperlink_Click(object sender, RoutedEventArgs e)
+        private async void Hyperlink_Click(object sender, RoutedEventArgs e)
         {
             // タグクリック時は検索キーワードへ反映し、一覧を即時フィルタする。
             // Ctrl押下時は既存キーワードへAND相当で追記する。
@@ -44,16 +44,7 @@ namespace IndigoMovieManager.UserControls
                     keyword = item.DataContext.ToString();
                 }
 
-                // 検索キーワードをSearchBoxとViewModelにセット
-                ownerWindow.SearchBox.Text = keyword;
-                ownerWindow.MainVM.DbInfo.SearchKeyword = keyword;
-
-                // 検索処理を実行
-                ownerWindow.FilterAndSort(ownerWindow.MainVM.DbInfo.Sort, true);
-                ownerWindow.SelectFirstItem();
-
-                // SearchBoxにフォーカスを当てる
-                ownerWindow.SearchBox.Focus();
+                await ownerWindow.ApplySearchKeywordFromLinkAsync(keyword);
             }
         }
 

--- a/Views/Main/MainWindow.EverythingWatchPollPolicy.cs
+++ b/Views/Main/MainWindow.EverythingWatchPollPolicy.cs
@@ -83,7 +83,11 @@ namespace IndigoMovieManager
                 return false;
             }
 
-            MarkWatchWorkDeferredForBackgroundCatchUp("user-priority:everything-poll");
+            if (!TryMarkWatchWorkDeferredForUserPriorityCatchUp("user-priority:everything-poll"))
+            {
+                return false;
+            }
+
             DebugRuntimeLog.Write(
                 "watch-check",
                 "everything poll deferred by user priority"

--- a/Views/Main/MainWindow.EverythingWatchPollPolicy.cs
+++ b/Views/Main/MainWindow.EverythingWatchPollPolicy.cs
@@ -91,6 +91,40 @@ namespace IndigoMovieManager
             return true;
         }
 
+        // UI抑止や明示操作でpoll本体を逃がした周回では、待機間隔のためだけにDBへ寄らない。
+        internal static bool ShouldProbeEverythingWatchPollQueueLoad(
+            bool isDeferredByUiSuppression,
+            bool isDeferredByUserPriority
+        )
+        {
+            return !isDeferredByUiSuppression && !isDeferredByUserPriority;
+        }
+
+        // 明示操作中や再生中は、poll を細かく刻まず calm 間隔へ寄せて背後 wake-up を減らす。
+        internal static int ApplyEverythingWatchPollInteractionDelayPolicy(
+            int delayMs,
+            bool isDeferredByUiSuppression,
+            bool isDeferredByUserPriority,
+            bool isPlayerPlaybackActive
+        )
+        {
+            if (delayMs <= 0)
+            {
+                delayMs = EverythingWatchPollIntervalMs;
+            }
+
+            if (
+                !isDeferredByUiSuppression
+                && !isDeferredByUserPriority
+                && !isPlayerPlaybackActive
+            )
+            {
+                return delayMs;
+            }
+
+            return Math.Max(delayMs, EverythingWatchPollIntervalCalmMs);
+        }
+
         // 混雑度と直近の静かさを見て、Everything poll の待機間隔を決める。
         private int ResolveEverythingWatchPollDelayFromState(int queueActiveCount)
         {

--- a/Views/Main/MainWindow.EverythingWatchPollPolicy.cs
+++ b/Views/Main/MainWindow.EverythingWatchPollPolicy.cs
@@ -64,6 +64,33 @@ namespace IndigoMovieManager
             return false;
         }
 
+        // 明示操作中の Everything poll は入口で止め、重い eligible 判定へ入る前に catch-up へ逃がす。
+        internal static bool ShouldDeferEverythingWatchPollForUserPriority(
+            bool isUserPriorityActive
+        )
+        {
+            return ShouldDeferBackgroundWorkForUserPriority(
+                isUserPriorityActive,
+                isManualMode: false
+            );
+        }
+
+        // poll 自体は定期処理なので、検索などの明示操作中は1周見送り、解除後のwatchで追いつく。
+        private bool TryDeferEverythingWatchPollForUserPriority()
+        {
+            if (!ShouldDeferEverythingWatchPollForUserPriority(IsUserPriorityWorkActive()))
+            {
+                return false;
+            }
+
+            MarkWatchWorkDeferredForBackgroundCatchUp("user-priority:everything-poll");
+            DebugRuntimeLog.Write(
+                "watch-check",
+                "everything poll deferred by user priority"
+            );
+            return true;
+        }
+
         // 混雑度と直近の静かさを見て、Everything poll の待機間隔を決める。
         private int ResolveEverythingWatchPollDelayFromState(int queueActiveCount)
         {

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -379,6 +379,17 @@ namespace IndigoMovieManager
             _ = ApplyPendingPlayerPlaybackRequestAsync();
         }
 
+        private void UxVideoPlayer_MediaFailed(object sender, ExceptionRoutedEventArgs e)
+        {
+            // ロード失敗時も user-priority を解放し、背後監視を永久停止させない。
+            _hasPendingPlayerPlaybackRequest = false;
+            ReleasePendingPlayerUserPriorityWork();
+            DebugRuntimeLog.Write(
+                "ui-tempo",
+                $"player media load failed: {e?.ErrorException?.Message ?? "unknown"}"
+            );
+        }
+
         internal static double ResolveMediaDurationMaximumMilliseconds(
             Duration naturalDuration,
             double fallbackMaximum

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -452,8 +452,7 @@ namespace IndigoMovieManager
                 if (uxWebVideoPlayer != null)
                 {
                     // 全画面中は専用Window側で全面ストレッチさせ、MainWindow側サイズは持ち込まない。
-                    uxWebVideoPlayer.Width = double.NaN;
-                    uxWebVideoPlayer.Height = double.NaN;
+                    SetPlayerElementSizeIfChanged(uxWebVideoPlayer, double.NaN, double.NaN);
                 }
 
                 return;
@@ -486,11 +485,13 @@ namespace IndigoMovieManager
             if (_isWebViewPlayerActive)
             {
                 // WebView2 はプレイヤー枠いっぱいに広げ、内側余白だけを残して使い切る。
-                uxWebVideoPlayer.Width = availableWidth;
-                uxWebVideoPlayer.Height = availableHeight;
-                PlayerArea.Width = availableWidth;
-                PlayerArea.Height = availableHeight + controllerHeight;
-                PlayerController.Width = availableWidth;
+                SetPlayerElementSizeIfChanged(uxWebVideoPlayer, availableWidth, availableHeight);
+                SetPlayerElementSizeIfChanged(
+                    PlayerArea,
+                    availableWidth,
+                    availableHeight + controllerHeight
+                );
+                SetPlayerElementWidthIfChanged(PlayerController, availableWidth);
                 return;
             }
 
@@ -507,16 +508,67 @@ namespace IndigoMovieManager
             }
 
             // 動画面と操作バーの横幅を揃え、縦動画でも画面内へ収める。
-            uxVideoPlayer.Width = viewportSize.Width;
-            uxVideoPlayer.Height = viewportSize.Height;
+            SetPlayerElementSizeIfChanged(uxVideoPlayer, viewportSize.Width, viewportSize.Height);
             if (uxWebVideoPlayer != null)
             {
-                uxWebVideoPlayer.Width = viewportSize.Width;
-                uxWebVideoPlayer.Height = viewportSize.Height;
+                SetPlayerElementSizeIfChanged(
+                    uxWebVideoPlayer,
+                    viewportSize.Width,
+                    viewportSize.Height
+                );
             }
-            PlayerArea.Width = viewportSize.Width;
-            PlayerArea.Height = viewportSize.Height + controllerHeight;
-            PlayerController.Width = viewportSize.Width;
+            SetPlayerElementSizeIfChanged(
+                PlayerArea,
+                viewportSize.Width,
+                viewportSize.Height + controllerHeight
+            );
+            SetPlayerElementWidthIfChanged(PlayerController, viewportSize.Width);
+        }
+
+        private static void SetPlayerElementSizeIfChanged(
+            FrameworkElement element,
+            double width,
+            double height
+        )
+        {
+            if (element == null)
+            {
+                return;
+            }
+
+            SetPlayerElementWidthIfChanged(element, width);
+            SetPlayerElementHeightIfChanged(element, height);
+        }
+
+        private static void SetPlayerElementWidthIfChanged(FrameworkElement element, double width)
+        {
+            if (element == null || ArePlayerLayoutLengthsEqual(element.Width, width))
+            {
+                return;
+            }
+
+            // 同じサイズの再設定を避け、Player user-priority 後の余計な measure を抑える。
+            element.Width = width;
+        }
+
+        private static void SetPlayerElementHeightIfChanged(FrameworkElement element, double height)
+        {
+            if (element == null || ArePlayerLayoutLengthsEqual(element.Height, height))
+            {
+                return;
+            }
+
+            element.Height = height;
+        }
+
+        private static bool ArePlayerLayoutLengthsEqual(double current, double next)
+        {
+            if (double.IsNaN(current) && double.IsNaN(next))
+            {
+                return true;
+            }
+
+            return Math.Abs(current - next) < 0.0001d;
         }
 
         private void EnsureManualPlayerResizeTrackingHooked()

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -34,11 +34,13 @@ namespace IndigoMovieManager
             return Math.Max(0d, Math.Min(1d, volume));
         }
 
-        // 保存値が初期化落ちして 0 へ戻った時は、起動時だけ既定の 50% へ戻す。
+        // 保存値が初期化落ちして 0%/100% へ戻った時は、起動時だけ既定の 50% へ戻す。
         private static double ResolveSavedPlayerVolumeSetting(double volume)
         {
             double resolvedVolume = ClampPlayerVolumeSetting(volume);
-            return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;
+            return resolvedVolume <= 0d || resolvedVolume >= 1d
+                ? DefaultPlayerVolume
+                : resolvedVolume;
         }
 
         // 画面表示と保存値を同じ音量へ寄せ、次に開く動画にもそのまま引き継ぐ。

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -34,13 +34,11 @@ namespace IndigoMovieManager
             return Math.Max(0d, Math.Min(1d, volume));
         }
 
-        // 保存値が初期化落ちして 0%/100% へ戻った時は、起動時だけ既定の 50% へ戻す。
+        // 保存値が初期化落ちして 0% へ戻った時は、起動時だけ既定の 50% へ戻す。
         private static double ResolveSavedPlayerVolumeSetting(double volume)
         {
             double resolvedVolume = ClampPlayerVolumeSetting(volume);
-            return resolvedVolume <= 0d || resolvedVolume >= 1d
-                ? DefaultPlayerVolume
-                : resolvedVolume;
+            return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;
         }
 
         // 画面表示と保存値を同じ音量へ寄せ、次に開く動画にもそのまま引き継ぐ。

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -55,8 +55,12 @@ namespace IndigoMovieManager
                 uxVolume.Text = ((int)(resolvedVolume * 100)).ToString();
             }
 
-            Properties.Settings.Default.PlayerVolume = resolvedVolume;
-            QueuePlayerVolumeSettingSave();
+            // WebView から同じ音量通知が返ってきた時は、保存キューだけ積み直さない。
+            if (Math.Abs(Properties.Settings.Default.PlayerVolume - resolvedVolume) > 0.0001d)
+            {
+                Properties.Settings.Default.PlayerVolume = resolvedVolume;
+                QueuePlayerVolumeSettingSave();
+            }
 
             if (!pushToWebView || uxWebVideoPlayer?.CoreWebView2 == null)
             {

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -382,12 +382,22 @@ namespace IndigoMovieManager
         private void UxVideoPlayer_MediaFailed(object sender, ExceptionRoutedEventArgs e)
         {
             // ロード失敗時も user-priority を解放し、背後監視を永久停止させない。
+            IsPlaying = false;
             _hasPendingPlayerPlaybackRequest = false;
             ReleasePendingPlayerUserPriorityWork();
+            StopDispatcherTimerSafely(timer, nameof(timer));
             DebugRuntimeLog.Write(
                 "ui-tempo",
                 $"player media load failed: {e?.ErrorException?.Message ?? "unknown"}"
             );
+        }
+
+        private void UxVideoPlayer_MediaEnded(object sender, RoutedEventArgs e)
+        {
+            // 再生終了後は poll の再生中扱いを解除し、通常の監視間隔へ戻す。
+            IsPlaying = false;
+            StopDispatcherTimerSafely(timer, nameof(timer));
+            UpdatePlayerPositionUi(uxVideoPlayer.Position);
         }
 
         internal static double ResolveMediaDurationMaximumMilliseconds(

--- a/Views/Main/MainWindow.Player.cs
+++ b/Views/Main/MainWindow.Player.cs
@@ -34,11 +34,13 @@ namespace IndigoMovieManager
             return Math.Max(0d, Math.Min(1d, volume));
         }
 
-        // 保存値が初期化落ちして 0% へ戻った時は、起動時だけ既定の 50% へ戻す。
+        // 保存値が初期化落ちして 0%/100% へ戻った時は、起動時だけ既定の 50% へ戻す。
         private static double ResolveSavedPlayerVolumeSetting(double volume)
         {
             double resolvedVolume = ClampPlayerVolumeSetting(volume);
-            return resolvedVolume <= 0d ? DefaultPlayerVolume : resolvedVolume;
+            return resolvedVolume <= 0d || resolvedVolume >= 1d
+                ? DefaultPlayerVolume
+                : resolvedVolume;
         }
 
         // 画面表示と保存値を同じ音量へ寄せ、次に開く動画にもそのまま引き継ぐ。
@@ -66,7 +68,7 @@ namespace IndigoMovieManager
             }
 
             _ = uxWebVideoPlayer.ExecuteScriptAsync(
-                $"const player = document.querySelector('video'); if (player) {{ player.muted = false; player.volume = {resolvedVolume.ToString(System.Globalization.CultureInfo.InvariantCulture)}; player.dataset.indigoPlayerHostVolumeApplied = '1'; }}"
+                $"const player = document.querySelector('video'); if (player) {{ player.dataset.indigoPlayerHostVolumeApplying = '1'; player.muted = false; player.volume = {resolvedVolume.ToString(System.Globalization.CultureInfo.InvariantCulture)}; player.dataset.indigoPlayerHostVolumeApplied = '1'; setTimeout(() => {{ delete player.dataset.indigoPlayerHostVolumeApplying; }}, 0); }}"
             );
         }
 
@@ -105,6 +107,15 @@ namespace IndigoMovieManager
         private void SyncPlayerVolumeFromWebView(double volume)
         {
             double resolvedVolume = ClampPlayerVolumeSetting(volume);
+            double currentVolume = ClampPlayerVolumeSetting(uxVolumeSlider?.Value ?? DefaultPlayerVolume);
+            if (resolvedVolume >= 1d && currentVolume < 0.999d)
+            {
+                DebugRuntimeLog.Write(
+                    "ui-tempo",
+                    $"player webview default volume ignored: incoming={resolvedVolume:0.###} current={currentVolume:0.###}"
+                );
+                return;
+            }
 
             _isPlayerVolumeSyncingFromWebView = true;
             try

--- a/Views/Main/MainWindow.Search.cs
+++ b/Views/Main/MainWindow.Search.cs
@@ -350,6 +350,13 @@ namespace IndigoMovieManager
             return FilterAndSortAsync(sortId, shouldReload);
         }
 
+        public async Task ApplySearchKeywordFromLinkAsync(string keyword)
+        {
+            // タグ・詳細リンク検索も検索正本へ合流させ、通常時のDB再読込を避ける。
+            await SearchExecutor.ExecuteAsync(keyword ?? "", syncSearchText: true);
+            SearchBox.Focus();
+        }
+
         // 変換途中の記号入力や部分ロード中は既存の確定検索へ寄せ、通常時だけ debounce で流す。
         private void QueueIncrementalSearch(string text)
         {

--- a/Views/Main/MainWindow.Search.cs
+++ b/Views/Main/MainWindow.Search.cs
@@ -352,7 +352,8 @@ namespace IndigoMovieManager
 
         public async Task ApplySearchKeywordFromLinkAsync(string keyword)
         {
-            // タグ・詳細リンク検索も検索正本へ合流させ、通常時のDB再読込を避ける。
+            // タグ・詳細・ブックマークリンク検索を検索正本へ合流させ、
+            // 通常時のDB再読込を避ける。
             await SearchExecutor.ExecuteAsync(keyword ?? "", syncSearchText: true);
             SearchBox.Focus();
         }

--- a/Views/Main/MainWindow.Search.cs
+++ b/Views/Main/MainWindow.Search.cs
@@ -354,8 +354,22 @@ namespace IndigoMovieManager
         {
             // タグ・詳細・ブックマークリンク検索を検索正本へ合流させ、
             // 通常時のDB再読込を避ける。
-            await SearchExecutor.ExecuteAsync(keyword ?? "", syncSearchText: true);
-            SearchBox.Focus();
+            try
+            {
+                await SearchExecutor.ExecuteAsync(keyword ?? "", syncSearchText: true);
+                // 既に検索欄にフォーカスがある時は再要求しない。
+                if (SearchBox != null && !SearchBox.IsKeyboardFocusWithin)
+                {
+                    SearchBox.Focus();
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugRuntimeLog.Write(
+                    "ui-tempo",
+                    $"link search failed: {ex.GetType().Name}: {ex.Message}"
+                );
+            }
         }
 
         // 変換途中の記号入力や部分ロード中は既存の確定検索へ寄せ、通常時だけ debounce で流す。

--- a/Views/Main/MainWindow.Search.cs
+++ b/Views/Main/MainWindow.Search.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -12,6 +13,7 @@ namespace IndigoMovieManager
     {
         private bool _suppressSearchBoxTextChangedHandling = false;
         private SearchExecutionController _searchExecutor;
+        private long _searchHistoryRefreshStamp;
 
         // =================================================================================
         // 検索に関する UI イベント処理 (View層のロジック)
@@ -87,8 +89,8 @@ namespace IndigoMovieManager
 
             if (!string.IsNullOrEmpty(MainVM.DbInfo.SearchKeyword))
             {
-                // フォーカス離脱時の実績記録は service へ寄せ、UI は発火条件だけを持つ。
-                SearchHistoryService.RecordSearchUsage(
+                // フォーカス離脱時の実績記録は背景へ送り、UIイベントをDB I/Oで止めない。
+                QueueSearchHistoryUsageRecord(
                     MainVM.DbInfo.DBFullPath,
                     MainVM.DbInfo.SearchKeyword
                 );
@@ -280,12 +282,105 @@ namespace IndigoMovieManager
         private void PersistSearchHistoryAfterSearch(string text)
         {
             string keyword = text ?? "";
-            SearchHistoryService.PersistSuccessfulSearch(
-                MainVM?.DbInfo?.DBFullPath,
-                keyword,
-                MainVM?.DbInfo?.SearchCount ?? 0
+            string dbFullPath = MainVM?.DbInfo?.DBFullPath ?? "";
+            int searchCount = MainVM?.DbInfo?.SearchCount ?? 0;
+            string currentText = SearchBox?.Text ?? "";
+            QueueSearchHistoryRefresh(dbFullPath, keyword, searchCount, currentText);
+        }
+
+        private void QueueSearchHistoryRefresh(
+            string dbFullPath,
+            string keyword,
+            int searchCount,
+            string currentText
+        )
+        {
+            if (
+                string.IsNullOrWhiteSpace(dbFullPath)
+                || string.IsNullOrWhiteSpace(keyword)
+                || searchCount <= 0
+            )
+            {
+                return;
+            }
+
+            long refreshStamp = Interlocked.Increment(ref _searchHistoryRefreshStamp);
+            _ = Task.Run(
+                    () =>
+                    {
+                        SearchHistoryService.PersistSuccessfulSearch(
+                            dbFullPath,
+                            keyword,
+                            searchCount
+                        );
+                        return SearchHistoryService.LoadLatestHistory(dbFullPath);
+                    }
+                )
+                .ContinueWith(
+                    task =>
+                    {
+                        if (task.IsFaulted)
+                        {
+                            DebugRuntimeLog.Write(
+                                "search-history",
+                                $"history refresh failed: db='{dbFullPath}' keyword='{keyword}' err='{task.Exception?.GetBaseException().Message}'"
+                            );
+                            return;
+                        }
+
+                        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+                        {
+                            return;
+                        }
+
+                        _ = Dispatcher.BeginInvoke(
+                            new Action(
+                                () =>
+                                {
+                                    if (
+                                        refreshStamp != _searchHistoryRefreshStamp
+                                        || !AreSameMainDbPath(
+                                            dbFullPath,
+                                            MainVM?.DbInfo?.DBFullPath ?? ""
+                                        )
+                                    )
+                                    {
+                                        return;
+                                    }
+
+                                    ApplySearchHistoryRecords(task.Result, currentText);
+                                }
+                            ),
+                            DispatcherPriority.Background
+                        );
+                    },
+                    TaskScheduler.Default
+                );
+        }
+
+        private void QueueSearchHistoryUsageRecord(string dbFullPath, string keyword)
+        {
+            if (string.IsNullOrWhiteSpace(dbFullPath) || string.IsNullOrWhiteSpace(keyword))
+            {
+                return;
+            }
+
+            _ = Task.Run(
+                () =>
+                {
+                    try
+                    {
+                        SearchHistoryService.RecordSearchUsage(dbFullPath, keyword);
+                    }
+                    catch (Exception ex)
+                    {
+                        DebugRuntimeLog.Write(
+                            "search-history",
+                            $"history usage record failed: db='{dbFullPath}' keyword='{keyword}' err='{ex.Message}'"
+                        );
+                    }
+                }
             );
-            GetHistoryTable(MainVM.DbInfo.DBFullPath);
         }
 
         // 検索 UI が複数になっても、本体検索の入口は 1 つへ寄せる。

--- a/Views/Main/MainWindow.Selection.cs
+++ b/Views/Main/MainWindow.Selection.cs
@@ -85,7 +85,10 @@ namespace IndigoMovieManager
             {
                 if (sourceList != null)
                 {
-                    sourceList.SelectedItem = record;
+                    if (!ReferenceEquals(sourceList.SelectedItem, record))
+                    {
+                        sourceList.SelectedItem = record;
+                    }
                 }
 
                 SyncPlayerThumbnailSelectionAcrossViews(sourceList, record);

--- a/Views/Main/MainWindow.xaml
+++ b/Views/Main/MainWindow.xaml
@@ -731,6 +731,7 @@
                               x:Name="uxVideoPlayer"
                               Grid.Row="0"
                               LoadedBehavior="Manual"
+                              MediaFailed="UxVideoPlayer_MediaFailed"
                               MediaOpened="UxVideoPlayer_MediaOpened"
                               PreviewMouseDown="UxVideoPlayer_PreviewMouseDown"
                               ScrubbingEnabled="true"

--- a/Views/Main/MainWindow.xaml
+++ b/Views/Main/MainWindow.xaml
@@ -731,6 +731,7 @@
                               x:Name="uxVideoPlayer"
                               Grid.Row="0"
                               LoadedBehavior="Manual"
+                              MediaEnded="UxVideoPlayer_MediaEnded"
                               MediaFailed="UxVideoPlayer_MediaFailed"
                               MediaOpened="UxVideoPlayer_MediaOpened"
                               PreviewMouseDown="UxVideoPlayer_PreviewMouseDown"
@@ -745,6 +746,7 @@
                               Grid.Row="0"
                               HorizontalAlignment="Stretch"
                               NavigationCompleted="UxWebVideoPlayer_NavigationCompleted"
+                              NavigationStarting="UxWebVideoPlayer_NavigationStarting"
                               VerticalAlignment="Stretch"
                               Visibility="Collapsed"
                             />

--- a/Views/Main/MainWindow.xaml.cs
+++ b/Views/Main/MainWindow.xaml.cs
@@ -1879,10 +1879,15 @@ namespace IndigoMovieManager
                 startupFeedLoadedAllPages: _startupFeedLoadedAllPages,
                 isGetNew: isGetNew
             );
+            string fullReloadReason = MainWindow.ResolveFilterSortFullReloadReason(
+                hasSnapshotData: latestMovieData != null,
+                startupFeedLoadedAllPages: _startupFeedLoadedAllPages,
+                isGetNew: isGetNew
+            );
 
             DebugRuntimeLog.Write(
                 "ui-tempo",
-                $"filter start: revision={requestRevision} sort={id} route={executionRoute} is_get_new={isGetNew} keyword='{MainVM.DbInfo.SearchKeyword}'"
+                $"filter start: revision={requestRevision} sort={id} route={executionRoute} full_reload_reason={fullReloadReason} is_get_new={isGetNew} keyword='{MainVM.DbInfo.SearchKeyword}'"
             );
 
             if ((latestMovieData == null && !_startupFeedLoadedAllPages) || isGetNew)
@@ -2064,7 +2069,7 @@ namespace IndigoMovieManager
             totalStopwatch.Stop();
             DebugRuntimeLog.Write(
                 "ui-tempo",
-                $"filter end: revision={requestRevision} sort={id} route={executionRoute} is_get_new={isGetNew} count={MainVM.DbInfo.SearchCount} changed={applyResult.HasChanges} update_mode={updateMode} refresh_applied={shouldRefresh} prefix={applyResult.RetainedPrefixCount} suffix={applyResult.RetainedSuffixCount} removed={applyResult.RemovedCount} inserted={applyResult.InsertedCount} moved={applyResult.MovedCount} db_reload_ms={dbLoadElapsedMs} source_apply_ms={sourceApplyElapsedMs} filter_sort_ms={filterSortElapsedMs} refresh_ms={refreshElapsedMs} total_ms={totalStopwatch.ElapsedMilliseconds}"
+                $"filter end: revision={requestRevision} sort={id} route={executionRoute} full_reload_reason={fullReloadReason} is_get_new={isGetNew} count={MainVM.DbInfo.SearchCount} changed={applyResult.HasChanges} update_mode={updateMode} refresh_applied={shouldRefresh} prefix={applyResult.RetainedPrefixCount} suffix={applyResult.RetainedSuffixCount} removed={applyResult.RemovedCount} inserted={applyResult.InsertedCount} moved={applyResult.MovedCount} db_reload_ms={dbLoadElapsedMs} source_apply_ms={sourceApplyElapsedMs} filter_sort_ms={filterSortElapsedMs} refresh_ms={refreshElapsedMs} total_ms={totalStopwatch.ElapsedMilliseconds}"
             );
         }
 
@@ -2463,6 +2468,26 @@ namespace IndigoMovieManager
             return ((!hasSnapshotData && !startupFeedLoadedAllPages) || isGetNew)
                 ? "full-reload"
                 : "query-only";
+        }
+
+        // full reload へ戻る理由を短い札にし、次の差分化候補をログから拾えるようにする。
+        internal static string ResolveFilterSortFullReloadReason(
+            bool hasSnapshotData,
+            bool startupFeedLoadedAllPages,
+            bool isGetNew
+        )
+        {
+            if (isGetNew)
+            {
+                return "is-get-new";
+            }
+
+            if (!hasSnapshotData && !startupFeedLoadedAllPages)
+            {
+                return "no-snapshot-startup-partial";
+            }
+
+            return "none";
         }
 
         // changed movie が現在の sort key に触っていないなら、既存の並び順をそのまま使える。

--- a/Views/Main/MainWindow.xaml.cs
+++ b/Views/Main/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
@@ -1700,14 +1701,21 @@ namespace IndigoMovieManager
         {
             // 現在のテキストを一時保存
             string currentText = SearchBox?.Text ?? "";
+            ApplySearchHistoryRecords(
+                SearchHistoryService.LoadLatestHistory(dbFullPath),
+                currentText
+            );
+        }
 
+        private void ApplySearchHistoryRecords(IEnumerable<History> historyRecords, string currentText)
+        {
             bool previousSuppressState = _suppressSearchBoxTextChangedHandling;
             _suppressSearchBoxTextChangedHandling = true;
             try
             {
                 historyData = null;
                 MainVM.HistoryRecs.Clear();
-                foreach (History item in SearchHistoryService.LoadLatestHistory(dbFullPath))
+                foreach (History item in historyRecords ?? [])
                 {
                     MainVM.HistoryRecs.Add(item);
                 }

--- a/Views/Main/MainWindow.xaml.cs
+++ b/Views/Main/MainWindow.xaml.cs
@@ -1207,6 +1207,10 @@ namespace IndigoMovieManager
                     {
                         MarkWatchWorkDeferredWhileSuppressed("everything-poll");
                     }
+                    else if (TryDeferEverythingWatchPollForUserPriority())
+                    {
+                        // 明示操作が終わった後の catch-up へ任せ、この周回では入口判定まで進めない。
+                    }
                     else if (ShouldRunEverythingWatchPollPolicy())
                     {
                         await QueueCheckFolderAsync(CheckMode.Watch, "EverythingPoll");

--- a/Views/Main/MainWindow.xaml.cs
+++ b/Views/Main/MainWindow.xaml.cs
@@ -1203,20 +1203,32 @@ namespace IndigoMovieManager
             {
                 try
                 {
+                    bool isDeferredByUiSuppression = false;
+                    bool isDeferredByUserPriority = false;
                     if (IsWatchSuppressedByUi())
                     {
                         MarkWatchWorkDeferredWhileSuppressed("everything-poll");
+                        isDeferredByUiSuppression = true;
                     }
                     else if (TryDeferEverythingWatchPollForUserPriority())
                     {
                         // 明示操作が終わった後の catch-up へ任せ、この周回では入口判定まで進めない。
+                        isDeferredByUserPriority = true;
                     }
                     else if (ShouldRunEverythingWatchPollPolicy())
                     {
                         await QueueCheckFolderAsync(CheckMode.Watch, "EverythingPoll");
                     }
 
-                    int delayMs = ResolveEverythingWatchPollDelayMs();
+                    int delayMs = ResolveEverythingWatchPollDelayMs(
+                        shouldProbeQueueLoad: ShouldProbeEverythingWatchPollQueueLoad(
+                            isDeferredByUiSuppression,
+                            isDeferredByUserPriority
+                        ),
+                        isDeferredByUiSuppression: isDeferredByUiSuppression,
+                        isDeferredByUserPriority: isDeferredByUserPriority,
+                        isPlayerPlaybackActive: IsPlaying
+                    );
                     await Task.Delay(delayMs, cts);
                 }
                 catch (OperationCanceledException)
@@ -1245,15 +1257,30 @@ namespace IndigoMovieManager
         /// サムネイルキュー負荷に応じてEverythingポーリング間隔を動的に調整する。
         /// キュー残量が多い時はポーリングを15秒に延ばし、CPUの空振り消費を抑える。
         /// </summary>
-        private int ResolveEverythingWatchPollDelayMs()
+        private int ResolveEverythingWatchPollDelayMs(
+            bool shouldProbeQueueLoad = true,
+            bool isDeferredByUiSuppression = false,
+            bool isDeferredByUserPriority = false,
+            bool isPlayerPlaybackActive = false
+        )
         {
             int delayMs = EverythingWatchPollIntervalMs;
             try
             {
-                var queueDbService = ResolveCurrentQueueDbService();
-                int activeCount = queueDbService?.GetActiveQueueCount(thumbnailQueueOwnerInstanceId)
-                    ?? 0;
+                int activeCount = 0;
+                if (shouldProbeQueueLoad)
+                {
+                    var queueDbService = ResolveCurrentQueueDbService();
+                    activeCount =
+                        queueDbService?.GetActiveQueueCount(thumbnailQueueOwnerInstanceId) ?? 0;
+                }
                 delayMs = ResolveEverythingWatchPollDelayFromState(activeCount);
+                delayMs = ApplyEverythingWatchPollInteractionDelayPolicy(
+                    delayMs,
+                    isDeferredByUiSuppression,
+                    isDeferredByUserPriority,
+                    isPlayerPlaybackActive
+                );
             }
             catch (Exception ex)
             {

--- a/Views/Main/MainWindow.xaml.cs
+++ b/Views/Main/MainWindow.xaml.cs
@@ -2102,6 +2102,7 @@ namespace IndigoMovieManager
             int searchCount = 0;
             bool usedChangedPathRefresh = false;
             bool canReuseCurrentOrder = false;
+            string changedPathFallbackReason = "none";
 
             DebugRuntimeLog.Write(
                 "ui-tempo",
@@ -2111,7 +2112,7 @@ namespace IndigoMovieManager
             Stopwatch filterSortStopwatch = Stopwatch.StartNew();
             await Task.Run(() =>
             {
-                usedChangedPathRefresh = TryBuildChangedMovieRefreshSource(
+                usedChangedPathRefresh = TryBuildChangedMovieRefreshSourceWithReason(
                     sourceMovies,
                     currentFilteredMovies,
                     searchKeyword,
@@ -2119,7 +2120,8 @@ namespace IndigoMovieManager
                     changedMovies,
                     MainVM.FilterMovies,
                     out filtered,
-                    out canReuseCurrentOrder
+                    out canReuseCurrentOrder,
+                    out changedPathFallbackReason
                 );
                 if (!usedChangedPathRefresh)
                 {
@@ -2184,7 +2186,7 @@ namespace IndigoMovieManager
             totalStopwatch.Stop();
             DebugRuntimeLog.Write(
                 "ui-tempo",
-                $"{resolvedTraceName} refresh end: revision={requestRevision} sort={resolvedSortId} count={searchCount} changed={applyResult.HasChanges} changed_path_mode={(usedChangedPathRefresh ? "partial" : "full")} reuse_order={canReuseCurrentOrder} prefix={applyResult.RetainedPrefixCount} suffix={applyResult.RetainedSuffixCount} removed={applyResult.RemovedCount} inserted={applyResult.InsertedCount} moved={applyResult.MovedCount} filter_sort_ms={filterSortStopwatch.ElapsedMilliseconds} total_ms={totalStopwatch.ElapsedMilliseconds}"
+                $"{resolvedTraceName} refresh end: revision={requestRevision} sort={resolvedSortId} count={searchCount} changed={applyResult.HasChanges} changed_path_mode={(usedChangedPathRefresh ? "partial" : "full")} changed_path_fallback={changedPathFallbackReason} reuse_order={canReuseCurrentOrder} prefix={applyResult.RetainedPrefixCount} suffix={applyResult.RetainedSuffixCount} removed={applyResult.RemovedCount} inserted={applyResult.InsertedCount} moved={applyResult.MovedCount} filter_sort_ms={filterSortStopwatch.ElapsedMilliseconds} total_ms={totalStopwatch.ElapsedMilliseconds}"
             );
         }
 
@@ -2268,11 +2270,44 @@ namespace IndigoMovieManager
             out bool canReuseCurrentOrder
         )
         {
+            return TryBuildChangedMovieRefreshSourceWithReason(
+                sourceMovies,
+                currentFilteredMovies,
+                searchKeyword,
+                sortId,
+                changedMovies,
+                filterMovies,
+                out nextFilteredMovies,
+                out canReuseCurrentOrder,
+                out _
+            );
+        }
+
+        internal static bool TryBuildChangedMovieRefreshSourceWithReason(
+            IEnumerable<MovieRecords> sourceMovies,
+            IEnumerable<MovieRecords> currentFilteredMovies,
+            string searchKeyword,
+            string sortId,
+            IEnumerable<WatchChangedMovie> changedMovies,
+            Func<IEnumerable<MovieRecords>, string, IEnumerable<MovieRecords>> filterMovies,
+            out MovieRecords[] nextFilteredMovies,
+            out bool canReuseCurrentOrder,
+            out string fallbackReason
+        )
+        {
             nextFilteredMovies = [];
             canReuseCurrentOrder = false;
+            fallbackReason = "none";
             List<WatchChangedMovie> normalizedChangedMovies = MainWindow.MergeChangedMovies([], changedMovies);
-            if (normalizedChangedMovies.Count < 1 || filterMovies == null)
+            if (normalizedChangedMovies.Count < 1)
             {
+                fallbackReason = "no-changed-movies";
+                return false;
+            }
+
+            if (filterMovies == null)
+            {
+                fallbackReason = "filter-unavailable";
                 return false;
             }
 
@@ -2288,6 +2323,7 @@ namespace IndigoMovieManager
                 )
             )
             {
+                fallbackReason = "dup-hash-dirty";
                 return false;
             }
 

--- a/Watcher/MainWindow.UserPriorityRuntime.cs
+++ b/Watcher/MainWindow.UserPriorityRuntime.cs
@@ -47,11 +47,7 @@ namespace IndigoMovieManager
                 }
 
                 isStillActive = _userPriorityWorkCount > 0;
-                hasDeferredWatchWork = _watchWorkDeferredWhileSuppressed;
-                if (!isStillActive && hasDeferredWatchWork)
-                {
-                    _watchWorkDeferredWhileSuppressed = false;
-                }
+                hasDeferredWatchWork = !isStillActive && ConsumeWatchWorkDeferredForUserPriorityCatchUp();
             }
 
             if (!wasActive)
@@ -84,6 +80,59 @@ namespace IndigoMovieManager
             lock (_userPriorityWorkSync)
             {
                 return _userPriorityWorkCount > 0;
+            }
+        }
+
+        // user-priority の解除と defer 記録を同じロック順に寄せ、解除境界の catch-up 取りこぼしを防ぐ。
+        private bool TryMarkWatchWorkDeferredForUserPriorityCatchUp(string trigger)
+        {
+            if (_userPriorityWorkSync == null || _watchUiSuppressionSync == null)
+            {
+                return false;
+            }
+
+            bool shouldLog = false;
+            lock (_userPriorityWorkSync)
+            {
+                if (_userPriorityWorkCount <= 0)
+                {
+                    return false;
+                }
+
+                lock (_watchUiSuppressionSync)
+                {
+                    shouldLog = !_watchWorkDeferredWhileSuppressed;
+                    _watchWorkDeferredWhileSuppressed = true;
+                }
+            }
+
+            if (shouldLog)
+            {
+                DebugRuntimeLog.Write(
+                    "watch-check",
+                    $"watch work deferred for background catch-up: trigger={trigger}"
+                );
+            }
+
+            return true;
+        }
+
+        private bool ConsumeWatchWorkDeferredForUserPriorityCatchUp()
+        {
+            if (_watchUiSuppressionSync == null)
+            {
+                return false;
+            }
+
+            lock (_watchUiSuppressionSync)
+            {
+                bool hasDeferredWatchWork = _watchWorkDeferredWhileSuppressed;
+                if (hasDeferredWatchWork)
+                {
+                    _watchWorkDeferredWhileSuppressed = false;
+                }
+
+                return hasDeferredWatchWork;
             }
         }
 

--- a/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
+++ b/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
@@ -11,6 +11,8 @@ namespace IndigoMovieManager
         private readonly object _checkFolderRequestSync = new();
         private bool _hasPendingCheckFolderRequest;
         private CheckMode _pendingCheckFolderMode = CheckMode.Auto;
+        private bool _isCheckFolderRunActive;
+        private CheckMode _runningCheckFolderMode = CheckMode.Auto;
         private bool _hasPendingManualReloadDeferredRescueSuppression;
         private bool _isRunningManualReloadDeferredRescueSuppression;
 
@@ -29,6 +31,11 @@ namespace IndigoMovieManager
             }
 
             if (TryDeferQueueCheckFolderRequest(mode, trigger))
+            {
+                return Task.CompletedTask;
+            }
+
+            if (TrySkipRedundantEverythingPollScanRequest(mode, trigger))
             {
                 return Task.CompletedTask;
             }
@@ -106,6 +113,68 @@ namespace IndigoMovieManager
             }
         }
 
+        // EverythingPoll は定期確認なので、既に Watch/Manual が走る・待つ状態なら重ねて積まない。
+        private bool TrySkipRedundantEverythingPollScanRequest(CheckMode mode, string trigger)
+        {
+            bool shouldSkip;
+            CheckMode runningMode;
+            CheckMode pendingMode;
+            lock (_checkFolderRequestSync)
+            {
+                runningMode = _runningCheckFolderMode;
+                pendingMode = _pendingCheckFolderMode;
+                shouldSkip = ShouldSkipRedundantEverythingPollScanRequest(
+                    mode,
+                    trigger,
+                    _isCheckFolderRunActive,
+                    runningMode,
+                    _hasPendingCheckFolderRequest,
+                    pendingMode
+                );
+            }
+
+            if (!shouldSkip)
+            {
+                return false;
+            }
+
+            DebugRuntimeLog.Write(
+                "watch-check",
+                $"everything poll scan skipped as duplicate: running={runningMode} pending={pendingMode}"
+            );
+            return true;
+        }
+
+        private static bool ShouldSkipRedundantEverythingPollScanRequest(
+            CheckMode mode,
+            string trigger,
+            bool isRunActive,
+            CheckMode runningMode,
+            bool hasPendingRequest,
+            CheckMode pendingMode
+        )
+        {
+            if (
+                mode != CheckMode.Watch
+                || !string.Equals(trigger, "EverythingPoll", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return false;
+            }
+
+            if (isRunActive && IsWatchScanSupersetMode(runningMode))
+            {
+                return true;
+            }
+
+            return hasPendingRequest && IsWatchScanSupersetMode(pendingMode);
+        }
+
+        private static bool IsWatchScanSupersetMode(CheckMode mode)
+        {
+            return mode == CheckMode.Watch || mode == CheckMode.Manual;
+        }
+
         // 単一ランナーでキューを消化し、同時実行を防ぐ。
         private async Task ProcessCheckFolderQueueAsync()
         {
@@ -115,6 +184,7 @@ namespace IndigoMovieManager
             {
                 while (TryDequeuePendingCheckFolderMode(out CheckMode modeToRun))
                 {
+                    MarkCheckFolderRunActive(modeToRun);
                     bool suppressMissingThumbnailRescue =
                         TryBeginManualReloadDeferredRescueSuppression(modeToRun);
                     try
@@ -124,6 +194,7 @@ namespace IndigoMovieManager
                     finally
                     {
                         EndManualReloadDeferredRescueSuppression(suppressMissingThumbnailRescue);
+                        ClearCheckFolderRunActive(modeToRun);
                     }
                 }
             }
@@ -153,6 +224,28 @@ namespace IndigoMovieManager
                 mode = _pendingCheckFolderMode;
                 _hasPendingCheckFolderRequest = false;
                 return true;
+            }
+        }
+
+        // 実行中 mode を見える化し、poll が同種の後続走査を積む前に止められるようにする。
+        private void MarkCheckFolderRunActive(CheckMode mode)
+        {
+            lock (_checkFolderRequestSync)
+            {
+                _runningCheckFolderMode = mode;
+                _isCheckFolderRunActive = true;
+            }
+        }
+
+        private void ClearCheckFolderRunActive(CheckMode mode)
+        {
+            lock (_checkFolderRequestSync)
+            {
+                if (_isCheckFolderRunActive && _runningCheckFolderMode == mode)
+                {
+                    _isCheckFolderRunActive = false;
+                    _runningCheckFolderMode = CheckMode.Auto;
+                }
             }
         }
 

--- a/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
+++ b/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
@@ -119,9 +119,9 @@ namespace IndigoMovieManager
                     IsUserPriorityWorkActive(),
                     mode == CheckMode.Manual
                 )
+                && TryMarkWatchWorkDeferredForUserPriorityCatchUp($"user-priority:{trigger}")
             )
             {
-                MarkWatchWorkDeferredForBackgroundCatchUp($"user-priority:{trigger}");
                 DebugRuntimeLog.Write(
                     "watch-check",
                     $"scan request deferred by user priority: mode={mode} trigger={trigger}"

--- a/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
+++ b/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
@@ -15,6 +15,7 @@ namespace IndigoMovieManager
         private CheckMode _runningCheckFolderMode = CheckMode.Auto;
         private bool _hasPendingManualReloadDeferredRescueSuppression;
         private bool _isRunningManualReloadDeferredRescueSuppression;
+        private bool _isCheckFolderQueueShutdownRequested;
 
         // テストでは本経路の呼び出し回数だけ観測し、既存の制御自体はそのまま通す。
         internal Action<string, string> QueueCheckFolderAsyncRequestedForTesting { get; set; }
@@ -25,6 +26,11 @@ namespace IndigoMovieManager
         /// </summary>
         private Task QueueCheckFolderAsync(CheckMode mode, string trigger)
         {
+            if (TryRejectQueueCheckFolderRequestForShutdown(mode, trigger))
+            {
+                return Task.CompletedTask;
+            }
+
             if (TryInvokeQueueCheckFolderTestHook(mode, trigger, out Task testTask))
             {
                 return testTask;
@@ -49,6 +55,35 @@ namespace IndigoMovieManager
                 $"scan request queued: mode={mode} trigger={trigger}"
             );
             return ProcessCheckFolderQueueAsync();
+        }
+
+        private void BeginCheckFolderQueueShutdownForClosing()
+        {
+            lock (_checkFolderRequestSync)
+            {
+                _isCheckFolderQueueShutdownRequested = true;
+                _hasPendingCheckFolderRequest = false;
+            }
+        }
+
+        private bool TryRejectQueueCheckFolderRequestForShutdown(CheckMode mode, string trigger)
+        {
+            bool isShutdownRequested;
+            lock (_checkFolderRequestSync)
+            {
+                isShutdownRequested = _isCheckFolderQueueShutdownRequested;
+            }
+
+            if (!isShutdownRequested)
+            {
+                return false;
+            }
+
+            DebugRuntimeLog.Write(
+                "watch-check",
+                $"scan request skipped by shutdown: mode={mode} trigger={trigger}"
+            );
+            return true;
         }
 
         // テストフックが差し込まれている時だけ、通常キューを通さずに観測を優先する。

--- a/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
+++ b/Watcher/MainWindow.WatchCheckFolderQueueRuntime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,6 +12,9 @@ namespace IndigoMovieManager
         private readonly object _checkFolderRequestSync = new();
         private bool _hasPendingCheckFolderRequest;
         private CheckMode _pendingCheckFolderMode = CheckMode.Auto;
+        private string _pendingCheckFolderFirstTrigger;
+        private string _pendingCheckFolderLastTrigger;
+        private int _pendingCheckFolderCompressionCount;
         private bool _isCheckFolderRunActive;
         private CheckMode _runningCheckFolderMode = CheckMode.Auto;
         private bool _hasPendingManualReloadDeferredRescueSuppression;
@@ -20,6 +24,27 @@ namespace IndigoMovieManager
         // テストでは本経路の呼び出し回数だけ観測し、既存の制御自体はそのまま通す。
         internal Action<string, string> QueueCheckFolderAsyncRequestedForTesting { get; set; }
         internal Func<string, string, Task> QueueCheckFolderAsyncForTesting { get; set; }
+
+        private readonly struct CheckFolderQueueRequestTrace
+        {
+            internal CheckFolderQueueRequestTrace(
+                CheckMode mode,
+                string firstTrigger,
+                string lastTrigger,
+                int compressionCount
+            )
+            {
+                Mode = mode;
+                FirstTrigger = firstTrigger;
+                LastTrigger = lastTrigger;
+                CompressionCount = compressionCount;
+            }
+
+            internal CheckMode Mode { get; }
+            internal string FirstTrigger { get; }
+            internal string LastTrigger { get; }
+            internal int CompressionCount { get; }
+        }
 
         /// <summary>
         /// フォルダ更新要求をキューにブチ込む！連打されても後続1回に圧縮してPCの爆発を防ぐ超優秀な門番処理！🚧
@@ -48,11 +73,11 @@ namespace IndigoMovieManager
 
             QueueCheckFolderAsyncRequestedForTesting?.Invoke(mode.ToString(), trigger);
             RegisterManualReloadDeferredRescueSuppressionIfNeeded(mode, trigger);
-            EnqueueCheckFolderRequest(mode);
+            string queueTraceMessage = EnqueueCheckFolderRequest(mode, trigger);
 
             DebugRuntimeLog.Write(
                 "watch-check",
-                $"scan request queued: mode={mode} trigger={trigger}"
+                queueTraceMessage
             );
             return ProcessCheckFolderQueueAsync();
         }
@@ -63,6 +88,7 @@ namespace IndigoMovieManager
             {
                 _isCheckFolderQueueShutdownRequested = true;
                 _hasPendingCheckFolderRequest = false;
+                ClearPendingCheckFolderTrace();
             }
         }
 
@@ -133,19 +159,33 @@ namespace IndigoMovieManager
         }
 
         // pendingが既にある時は mode を強い側へマージし、後続1回へ圧縮する。
-        private void EnqueueCheckFolderRequest(CheckMode mode)
+        private string EnqueueCheckFolderRequest(CheckMode mode, string trigger)
         {
+            string queueTraceMessage;
             lock (_checkFolderRequestSync)
             {
                 if (_hasPendingCheckFolderRequest)
                 {
+                    CheckMode previousMode = _pendingCheckFolderMode;
                     _pendingCheckFolderMode = MergeCheckMode(_pendingCheckFolderMode, mode);
-                    return;
+                    _pendingCheckFolderLastTrigger = trigger;
+                    _pendingCheckFolderCompressionCount++;
+                    queueTraceMessage =
+                        $"scan request compressed: mode={previousMode}->{_pendingCheckFolderMode} {BuildWatchCheckFolderQueueTraceSummary(_pendingCheckFolderFirstTrigger, _pendingCheckFolderLastTrigger, _pendingCheckFolderCompressionCount)}";
                 }
-
-                _pendingCheckFolderMode = mode;
-                _hasPendingCheckFolderRequest = true;
+                else
+                {
+                    _pendingCheckFolderMode = mode;
+                    _pendingCheckFolderFirstTrigger = trigger;
+                    _pendingCheckFolderLastTrigger = trigger;
+                    _pendingCheckFolderCompressionCount = 0;
+                    _hasPendingCheckFolderRequest = true;
+                    queueTraceMessage =
+                        $"scan request accepted: mode={mode} {BuildWatchCheckFolderQueueTraceSummary(_pendingCheckFolderFirstTrigger, _pendingCheckFolderLastTrigger, _pendingCheckFolderCompressionCount)}";
+                }
             }
+
+            return queueTraceMessage;
         }
 
         // EverythingPoll は定期確認なので、既に Watch/Manual が走る・待つ状態なら重ねて積まない。
@@ -210,6 +250,55 @@ namespace IndigoMovieManager
             return mode == CheckMode.Watch || mode == CheckMode.Manual;
         }
 
+        // trigger文字列から由来とpathらしさだけを短く残し、圧縮後も因果を追える形へ整える。
+        private static string BuildWatchCheckFolderQueueTraceSummary(
+            string firstTrigger,
+            string lastTrigger,
+            int compressionCount
+        )
+        {
+            return
+                $"compressed={compressionCount} first={FormatWatchCheckFolderQueueTriggerForLog(firstTrigger)} last={FormatWatchCheckFolderQueueTriggerForLog(lastTrigger)}";
+        }
+
+        private static string FormatWatchCheckFolderQueueTriggerForLog(string trigger)
+        {
+            if (string.IsNullOrWhiteSpace(trigger))
+            {
+                return "empty";
+            }
+
+            int separatorIndex = trigger.IndexOf(':');
+            if (separatorIndex <= 0 || separatorIndex >= trigger.Length - 1)
+            {
+                return trigger;
+            }
+
+            string source = trigger.Substring(0, separatorIndex);
+            string value = trigger.Substring(separatorIndex + 1);
+            if (LooksLikeWindowsAbsolutePath(value))
+            {
+                string fileName = Path.GetFileName(value);
+                string pathText = string.IsNullOrEmpty(fileName) ? value : fileName;
+                return $"{source} path='{EscapeWatchCheckFolderQueueLogValue(pathText)}'";
+            }
+
+            return $"{source} value='{EscapeWatchCheckFolderQueueLogValue(value)}'";
+        }
+
+        private static bool LooksLikeWindowsAbsolutePath(string value)
+        {
+            return value.Length >= 3
+                && char.IsLetter(value[0])
+                && value[1] == ':'
+                && (value[2] == '\\' || value[2] == '/');
+        }
+
+        private static string EscapeWatchCheckFolderQueueLogValue(string value)
+        {
+            return value.Replace("'", "''");
+        }
+
         // 単一ランナーでキューを消化し、同時実行を防ぐ。
         private async Task ProcessCheckFolderQueueAsync()
         {
@@ -217,20 +306,36 @@ namespace IndigoMovieManager
 
             try
             {
-                while (TryDequeuePendingCheckFolderMode(out CheckMode modeToRun))
+                int processedCount = 0;
+                CheckFolderQueueRequestTrace lastTrace = default;
+                while (TryDequeuePendingCheckFolderRequest(out CheckFolderQueueRequestTrace request))
                 {
-                    MarkCheckFolderRunActive(modeToRun);
+                    DebugRuntimeLog.Write(
+                        "watch-check",
+                        $"scan request dequeued: mode={request.Mode} {BuildWatchCheckFolderQueueTraceSummary(request.FirstTrigger, request.LastTrigger, request.CompressionCount)}"
+                    );
+                    MarkCheckFolderRunActive(request.Mode);
                     bool suppressMissingThumbnailRescue =
-                        TryBeginManualReloadDeferredRescueSuppression(modeToRun);
+                        TryBeginManualReloadDeferredRescueSuppression(request.Mode);
                     try
                     {
-                        await CheckFolderAsync(modeToRun);
+                        await CheckFolderAsync(request.Mode);
+                        processedCount++;
+                        lastTrace = request;
                     }
                     finally
                     {
                         EndManualReloadDeferredRescueSuppression(suppressMissingThumbnailRescue);
-                        ClearCheckFolderRunActive(modeToRun);
+                        ClearCheckFolderRunActive(request.Mode);
                     }
+                }
+
+                if (processedCount > 0)
+                {
+                    DebugRuntimeLog.Write(
+                        "watch-check",
+                        $"scan queue drained: runs={processedCount} mode={lastTrace.Mode} {BuildWatchCheckFolderQueueTraceSummary(lastTrace.FirstTrigger, lastTrace.LastTrigger, lastTrace.CompressionCount)}"
+                    );
                 }
             }
             finally
@@ -246,20 +351,35 @@ namespace IndigoMovieManager
         }
 
         // pending の取り出しとdequeueを1か所に寄せ、runner側は処理ループだけを見る。
-        private bool TryDequeuePendingCheckFolderMode(out CheckMode mode)
+        private bool TryDequeuePendingCheckFolderRequest(
+            out CheckFolderQueueRequestTrace request
+        )
         {
             lock (_checkFolderRequestSync)
             {
                 if (!_hasPendingCheckFolderRequest)
                 {
-                    mode = CheckMode.Auto;
+                    request = default;
                     return false;
                 }
 
-                mode = _pendingCheckFolderMode;
+                request = new CheckFolderQueueRequestTrace(
+                    _pendingCheckFolderMode,
+                    _pendingCheckFolderFirstTrigger,
+                    _pendingCheckFolderLastTrigger,
+                    _pendingCheckFolderCompressionCount
+                );
                 _hasPendingCheckFolderRequest = false;
+                ClearPendingCheckFolderTrace();
                 return true;
             }
+        }
+
+        private void ClearPendingCheckFolderTrace()
+        {
+            _pendingCheckFolderFirstTrigger = null;
+            _pendingCheckFolderLastTrigger = null;
+            _pendingCheckFolderCompressionCount = 0;
         }
 
         // 実行中 mode を見える化し、poll が同種の後続走査を積む前に止められるようにする。

--- a/Watcher/MainWindow.WatchFolderFullReconcilePolicy.cs
+++ b/Watcher/MainWindow.WatchFolderFullReconcilePolicy.cs
@@ -203,12 +203,18 @@ public partial class MainWindow
 
         if (shouldDeferFullReconcileByUserPriority)
         {
-            MarkWatchWorkDeferredForBackgroundCatchUp($"watch-zero-diff-reconcile:{checkFolder}");
-            DebugRuntimeLog.Write(
-                "watch-check",
-                $"scan reconcile deferred by user priority: folder='{checkFolder}' reason=search-priority"
-            );
-            return false;
+            if (
+                TryMarkWatchWorkDeferredForUserPriorityCatchUp(
+                    $"watch-zero-diff-reconcile:{checkFolder}"
+                )
+            )
+            {
+                DebugRuntimeLog.Write(
+                    "watch-check",
+                    $"scan reconcile deferred by user priority: folder='{checkFolder}' reason=search-priority"
+                );
+                return false;
+            }
         }
 
         string reconcileScopeKey = BuildWatchFolderFullReconcileScopeKey(

--- a/Watcher/MainWindow.WatchUiSuppressionRuntime.cs
+++ b/Watcher/MainWindow.WatchUiSuppressionRuntime.cs
@@ -26,9 +26,11 @@ namespace IndigoMovieManager
                     IsUserPriorityWorkActive(),
                     mode == CheckMode.Manual
                 )
+                && TryMarkWatchWorkDeferredForUserPriorityCatchUp(
+                    $"check-start-user-priority:{mode}"
+                )
             )
             {
-                MarkWatchWorkDeferredForBackgroundCatchUp($"check-start-user-priority:{mode}");
                 return true;
             }
 
@@ -242,7 +244,7 @@ namespace IndigoMovieManager
             }
         }
 
-        // ユーザー優先で後ろへ逃がしたwatch仕事は、UI抑止中でなくても解除後のcatch-upへ必ず戻す。
+        // UI抑止由来の遅延は、UI抑止解除側の catch-up へ集約する。
         private void MarkWatchWorkDeferredForBackgroundCatchUp(string trigger)
         {
             bool shouldLog = false;

--- a/Watcher/MainWindow.WatchUiSuppressionRuntime.cs
+++ b/Watcher/MainWindow.WatchUiSuppressionRuntime.cs
@@ -154,6 +154,7 @@ namespace IndigoMovieManager
             bool wasSuppressed;
             bool isStillSuppressed;
             bool hasDeferredWatchWork;
+            bool shouldQueueCatchUp;
             bool shouldSkipCatchUp;
             lock (_watchUiSuppressionSync)
             {
@@ -174,13 +175,12 @@ namespace IndigoMovieManager
                 isStillSuppressed = _watchUiSuppressionCount > 0;
                 hasDeferredWatchWork = _watchWorkDeferredWhileSuppressed;
                 shouldSkipCatchUp = ShouldSkipWatchCatchUpAfterUiSuppression(reason);
-                if (
-                    wasSuppressed
+                shouldQueueCatchUp = wasSuppressed
                     && ShouldQueueWatchCatchUpAfterUiSuppression(
                         isStillSuppressed,
                         hasDeferredWatchWork
-                    )
-                )
+                    );
+                if (shouldQueueCatchUp && !shouldSkipCatchUp)
                 {
                     _watchWorkDeferredWhileSuppressed = false;
                 }
@@ -196,11 +196,15 @@ namespace IndigoMovieManager
                 DebugRuntimeLog.Write("watch-check", $"watch ui suppression end: reason={reason}");
             }
 
-            if (
-                ShouldQueueWatchCatchUpAfterUiSuppression(isStillSuppressed, hasDeferredWatchWork)
-                && shouldSkipCatchUp
-            )
+            if (shouldQueueCatchUp && shouldSkipCatchUp)
             {
+                // manual-reload 解除時に user-priority が残っている場合は、
+                // defer を user-priority 側の resume へ引き渡して取りこぼしを防ぐ。
+                if (!IsUserPriorityWorkActive())
+                {
+                    ClearDeferredWatchWorkByUiSuppression();
+                }
+
                 DebugRuntimeLog.Write(
                     "watch-check",
                     $"watch ui suppression catch-up skipped: reason={reason}"
@@ -208,9 +212,7 @@ namespace IndigoMovieManager
                 return;
             }
 
-            if (
-                ShouldQueueWatchCatchUpAfterUiSuppression(isStillSuppressed, hasDeferredWatchWork)
-            )
+            if (shouldQueueCatchUp)
             {
                 DebugRuntimeLog.Write(
                     "watch-check",

--- a/Watcher/MainWindow.WatcherEventQueue.cs
+++ b/Watcher/MainWindow.WatcherEventQueue.cs
@@ -63,6 +63,7 @@ namespace IndigoMovieManager
         // Closing開始後は新規イベント受付を止め、現在走っているqueue/taskだけを穏当にdrainする。
         private void BeginWatchEventQueueShutdownForClosing()
         {
+            BeginCheckFolderQueueShutdownForClosing();
             lock (_watchEventRequestSync)
             {
                 _watchEventShutdownRequested = true;

--- a/src/IndigoMovieManager.Thumbnail.Queue/ThumbnailProgressRuntime.cs
+++ b/src/IndigoMovieManager.Thumbnail.Queue/ThumbnailProgressRuntime.cs
@@ -54,6 +54,22 @@ namespace IndigoMovieManager.Thumbnail
             }
         }
 
+        // UIを先に戻した後、背景で数えた既存サムネ総数を後追い反映する。
+        public void ApplyInitialTotalCreatedCount(long initialTotalCreatedCount)
+        {
+            lock (stateLock)
+            {
+                long normalizedInitialTotalCreatedCount = Math.Max(0, initialTotalCreatedCount);
+                if (totalCreatedCount == normalizedInitialTotalCreatedCount)
+                {
+                    return;
+                }
+
+                totalCreatedCount = normalizedInitialTotalCreatedCount;
+                MarkStateDirty();
+            }
+        }
+
         // キュー投入ログは「動画名のみ」を最新N件で保持する。
         public void RecordEnqueue(QueueObj queueObj)
         {

--- a/src/IndigoMovieManager.Thumbnail.Queue/ThumbnailProgressRuntime.cs
+++ b/src/IndigoMovieManager.Thumbnail.Queue/ThumbnailProgressRuntime.cs
@@ -19,6 +19,7 @@ namespace IndigoMovieManager.Thumbnail
         private int sessionCompletedCount;
         private int sessionTotalCount;
         private long totalCreatedCount;
+        private long initialTotalCreatedCountBaseline;
         private int currentParallelism;
         private int configuredParallelism;
         private long stateVersion;
@@ -36,6 +37,7 @@ namespace IndigoMovieManager.Thumbnail
                     || sessionCompletedCount != 0
                     || sessionTotalCount != 0
                     || totalCreatedCount != normalizedInitialTotalCreatedCount
+                    || initialTotalCreatedCountBaseline != normalizedInitialTotalCreatedCount
                     || currentParallelism != 0
                     || configuredParallelism != 0;
 
@@ -45,6 +47,7 @@ namespace IndigoMovieManager.Thumbnail
                 sessionCompletedCount = 0;
                 sessionTotalCount = 0;
                 totalCreatedCount = normalizedInitialTotalCreatedCount;
+                initialTotalCreatedCountBaseline = normalizedInitialTotalCreatedCount;
                 currentParallelism = 0;
                 configuredParallelism = 0;
                 if (hasAnyState)
@@ -60,12 +63,15 @@ namespace IndigoMovieManager.Thumbnail
             lock (stateLock)
             {
                 long normalizedInitialTotalCreatedCount = Math.Max(0, initialTotalCreatedCount);
-                if (totalCreatedCount == normalizedInitialTotalCreatedCount)
+                long baselineDelta =
+                    normalizedInitialTotalCreatedCount - initialTotalCreatedCountBaseline;
+                if (baselineDelta <= 0)
                 {
                     return;
                 }
 
-                totalCreatedCount = normalizedInitialTotalCreatedCount;
+                totalCreatedCount += baselineDelta;
+                initialTotalCreatedCountBaseline = normalizedInitialTotalCreatedCount;
                 MarkStateDirty();
             }
         }


### PR DESCRIPTION
## 概要
- Player音量の保存値復元を見直し、0%へ初期化落ちした場合だけ50%へ戻し、ユーザーが意図した100%は有効値として維持します。
- WebViewから同じ音量通知が戻った場合は、表示反映は維持しつつ `Settings.Save()` のdebounceキューを積み直さないようにします。
- Player右側一覧の同一動画再同期では、`SelectedItem` 再代入、`ScrollIntoView`、visible range refresh を再投入しないようにします。
- `EverythingPoll` 起点のWatch走査は、既にWatch/Manual走査が実行中または保留中なら重複投入しないようにします。

## 確認
- `dotnet test Tests\IndigoMovieManager.Tests\IndigoMovieManager.Tests.csproj -c Debug -p:Platform=x64 -p:UseSharedCompilation=false --filter "FullyQualifiedName~ManualPlayerResizeHookPolicyTests|FullyQualifiedName~WatchScanCoordinatorPolicyTests|FullyQualifiedName~EverythingWatchPollPolicyTests"`
- `git diff --check`